### PR TITLE
docs: add concepts primer, BOINC guide, and README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ FluxCD GitOps cluster for KinD — multi-node, Cilium CNI with kube-proxy replac
 | [GitOps Flow](images/flow.svg) | End-to-end reconciliation flow from git commit to running pod, with dependency ordering |
 | [Network Topology](images/network-topology.svg) | KinD node layout, Cilium VXLAN pod network, ingress path, and Istio mesh traffic |
 
+## Documentation
+
+| Document | Description |
+|---|---|
+| [Key Concepts](docs/concepts.md) | What each technology is and why it's here — start here if you're new to Kubernetes |
+| [Troubleshooting Guide](docs/troubleshooting-guide.md) | Per-technology verification commands and common issue resolutions |
+| [SOPS + Age Secrets](docs/sops-age-secrets.md) | Secrets encryption setup, day-to-day workflow, and recovery procedure |
+| [BOINC](docs/boinc.md) | BOINC compute DaemonSet — status commands, credential updates, and troubleshooting |
+| [Kubescape Accepted Risks](docs/kubescape-security.md) | Security findings reviewed and accepted as intentional design decisions |
+| [Istio Basic Reference](docs/ISTIO_basic_notes.md) | Day-to-day Istio admin commands |
+| [Istio Advanced Reference](docs/ISTIO_advanced_notes.md) | mTLS enforcement, authorization policy, tracing config |
+
 ## Repository structure
 
 ```text
@@ -95,6 +107,29 @@ flux-cluster/
     └── setup-without-flux-generic-cluster.sh  # KinD cluster only (no Flux bootstrap)
 ```
 
+## How changes flow
+
+This cluster is fully GitOps — `kubectl apply` is never run directly. Every change
+enters through Git:
+
+```
+1. Edit a manifest or HelmRelease value locally
+2. git commit + git push to the branch Flux is watching
+3. Flux GitRepository detects the new commit (polls every 1 min)
+4. Flux Kustomization runs kustomize build and diffs the result against the cluster
+5. Changed resources are applied; HelmReleases trigger helm upgrade automatically
+6. The cluster converges to match the new desired state in Git
+```
+
+To skip the 1-minute poll and apply immediately after a push:
+
+```bash
+flux reconcile source git flux-system -n flux-system
+```
+
+Any change made with `kubectl apply` directly will be **reverted** on the next
+reconcile. Flux is the source of truth — always commit to Git instead.
+
 ## Dependency chain
 
 ```text
@@ -140,7 +175,7 @@ flux-system (GitRepository)
 | Envoy Gateway | envoy-gateway/gateway | 1.4.x | envoy-gateway-system | |
 | Envoy Gateway data-plane | gatewayClassName: eg | 1.4.x | envoy-ingress | |
 | kube-prometheus-stack | prometheus-community/kube-prometheus-stack | 72.x | observability | |
-| Grafana | grafana/grafana | 8.x | observability | |
+| Grafana | grafana/grafana | 10.x (app 12.x) | observability | |
 | Loki | grafana/loki | 6.x | observability | |
 | Promtail | grafana/promtail | 6.x | observability | |
 | Grafana Tempo | grafana/tempo | 1.x | observability | Single-binary mode; trace backend for the OTel pipeline |
@@ -150,6 +185,22 @@ flux-system (GitRepository)
 | Kubescape | kubescape/kubescape-operator | 1.40.x | kubescape | NSA + MITRE continuous scan; vulnerability scan disabled for KinD |
 | Falco + Falcosidekick | falcosecurity/falco | 8.x | falco | |
 | demo (httpbin) | kennethreitz/httpbin | @sha256 digest pin | demo | No versioned tags published; pinned by digest |
+| BOINC | boinc/client | arm64v8 | boinc | Voluntary compute — Rosetta@Home + Einstein@Home; capped at 1 CPU core for thermal management |
+
+## Container images
+
+Images referenced directly in manifests (outside of Helm charts). Helm-managed
+workloads use images defined by their chart; versions are controlled by the chart
+version constraint in the HelmRelease.
+
+| Image | Tag / Digest | File | Purpose |
+|-------|-------------|------|---------|
+| `boinc/client` | `arm64v8` | `apps/base/boinc/daemonset.yaml` | BOINC compute client (ARM64-native) |
+| `busybox` | `1.37` | `apps/base/boinc/daemonset.yaml` | initContainer: copies account XML credentials to hostPath |
+| `kennethreitz/httpbin` | `@sha256:599f…` | `apps/base/demo/httpbin.yaml` | HTTP echo server — mesh traffic target |
+| `curlimages/curl` | `8.7.1` | `apps/base/demo/load-generator.yaml` | Load generator: curl loop → httpbin every 5 s |
+| `nginx` | `1.27-alpine` | `apps/overlays/kind/istio/nodeport-proxy.yaml` | KinD ingress workaround: proxies host port 8888 → Envoy ClusterIP |
+| `falcosecurity/event-generator` | `0.13.0` | `tests/falco/event-generator.yaml` | Falco live detection test job |
 
 ## Version compatibility
 
@@ -164,7 +215,7 @@ The versions below were validated together. When upgrading a component, check co
 | Gateway API CRDs | v1.2.1 | hardcoded in `setup-fluxcd-gitops-kind-multinode.sh` step 4 |
 | kube-prometheus-stack | 72.x | `prometheus/helmrelease.yaml` |
 | Loki | 6.x | `loki/helmrelease.yaml` |
-| Grafana | 8.x | `grafana/helmrelease.yaml` |
+| Grafana | 10.x (app 12.x) | `grafana/helmrelease.yaml` |
 | Grafana Tempo | 1.x | `tempo/helmrelease.yaml` |
 | OpenTelemetry Collector | 0.x | `opentelemetry/helmrelease.yaml` |
 | Kyverno | 3.x | `kyverno.yaml` |
@@ -279,6 +330,47 @@ After bootstrap, watch Flux reconcile everything:
 flux get all -A
 watch -n 6 "flux get all -A"
 ```
+
+## After bootstrap — Day 1 checklist
+
+Work through these steps in order to confirm the cluster is fully healthy.
+
+```bash
+# 1. All nodes Ready
+kubectl get nodes
+
+# 2. All Flux resources reconciled — every row should show READY: True
+flux get all -A
+
+# 3. No pods stuck — filter out Running and Completed to spot problems
+kubectl get pods -A | grep -v "Running\|Completed"
+
+# 4. Cilium CNI healthy
+cilium status --wait
+
+# 5. Grafana reachable — expected: 302 (login redirect)
+curl -s -o /dev/null -w "%{http_code}" -H "Host: grafana.local" http://localhost:8080/
+
+# 6. Open Grafana: http://grafana.local:8080
+#    Navigate to Dashboards → Node Exporter Full
+#    Verify CPU, memory, and disk graphs have data
+
+# 7. Open the Istio Mesh dashboard
+#    Dashboards → Istio Mesh
+#    Verify request rate > 0 (generated by load-generator in the demo namespace)
+
+# 8. Verify all five Kyverno ClusterPolicies loaded
+kubectl get clusterpolicies
+
+# 9. Verify BOINC attached to both projects
+kubectl logs -n boinc -l app=boinc --tail=30 | grep -iE "project|attach"
+
+# 10. Run offline policy unit tests (no cluster required)
+make test-policies
+```
+
+If any step fails, see the [Troubleshooting Guide](docs/troubleshooting-guide.md) and
+jump to the relevant technology section.
 
 ## Accessing services
 

--- a/docs/boinc.md
+++ b/docs/boinc.md
@@ -1,0 +1,213 @@
+# BOINC — Distributed Computing
+
+Cluster: `flux-kind` · Image: `boinc/client:arm64v8` · DaemonSet in `boinc` namespace
+
+---
+
+## What is BOINC
+
+BOINC (Berkeley Open Infrastructure for Network Computing) donates idle CPU cycles to
+scientific research. When the cluster is not under load, BOINC uses spare CPU to run
+computations and submits results back to project servers over the internet.
+
+This cluster participates in two projects:
+
+| Project | Server | Research area |
+|---------|--------|---------------|
+| Rosetta@Home | boinc.bakerlab.org | Protein structure prediction — medical research |
+| Einstein@Home | einstein.phys.uwm.edu | Gravitational wave and pulsar detection |
+
+Each project receives an equal share of available CPU time (50/50 split) via equal
+`resource_share` values in the account XML files.
+
+---
+
+## Architecture
+
+BOINC runs as a DaemonSet — one pod per cluster node — and uses a `hostPath` volume at
+`/var/lib/boinc` so work-in-progress task checkpoints survive pod restarts.
+
+### Why hostPath instead of a PVC
+
+BOINC continuously writes checkpoint files and commits them with atomic `rename()`
+syscalls. Kubernetes Secret `subPath` mounts create read-only bind mounts that the
+`rename()` syscall cannot move files over (`EBUSY`). The hostPath volume is writable
+and avoids this limitation entirely.
+
+### initContainer pattern for credentials
+
+Project credentials are stored in a SOPS-encrypted Secret (`boinc-projects-secret`).
+At pod startup, a `busybox` initContainer copies the account XML files from the Secret
+volume to the writable hostPath directory using `cp -n` (no-clobber):
+
+- **First start** — files do not exist on the host yet. `cp -n` copies them. BOINC
+  reads them on startup and attaches to both projects.
+- **Restart** — files already exist from the previous run. `cp -n` skips them. BOINC
+  preserves its full project state, including task progress and downloaded work units.
+
+### CPU limit and thermal management
+
+The DaemonSet is capped at `1000m` (1 CPU core out of 10 on the M5 chip). On the
+passively cooled MacBook Air M5, this keeps peak core temperatures below 65°C.
+Raising the limit above 1500m pushes cores to 74°C+, which is within Apple Silicon's
+safe operating range but above the thermal target for this cluster.
+
+---
+
+## Status commands
+
+```bash
+# Pod status — one pod per node, all should be Running
+kubectl get pods -n boinc -o wide
+
+# Watch BOINC startup and project attach messages
+kubectl logs -n boinc -l app=boinc --tail=50
+
+# Confirm both projects attached
+kubectl logs -n boinc -l app=boinc --tail=100 | grep -iE "attach|project|account"
+
+# Store a pod name for exec commands
+POD=$(kubectl get pod -n boinc -l app=boinc -o jsonpath='{.items[0].metadata.name}')
+
+# Check project status via boinccmd
+kubectl exec -n boinc $POD -- boinccmd --get_project_status
+
+# Check active work units
+kubectl exec -n boinc $POD -- boinccmd --get_tasks
+
+# Check CPU and memory usage as BOINC sees it
+kubectl exec -n boinc $POD -- boinccmd --get_host_info
+```
+
+Expected output from `--get_project_status`: two projects listed with URLs
+`https://boinc.bakerlab.org/rosetta/` and `https://einstein.phys.uwm.edu/`.
+
+---
+
+## Updating project credentials
+
+Credentials live in `apps/base/boinc/boinc-projects-secret.yaml` (SOPS-encrypted).
+The Secret contains three keys:
+
+| Key | Contents |
+|-----|----------|
+| `gui-rpc-password` | Local RPC password used by `boinccmd` |
+| `account_boinc.bakerlab.org_rosetta.xml` | Rosetta@Home account XML with authenticator key |
+| `account_einstein.phys.uwm.edu.xml` | Einstein@Home account XML with authenticator key |
+
+To update a credential:
+
+```bash
+# Opens the decrypted YAML in $EDITOR — re-encrypts automatically on save
+sops apps/base/boinc/boinc-projects-secret.yaml
+```
+
+After saving, commit and push. Flux will reconcile the updated Secret. Restart the
+DaemonSet to pick up the new credentials immediately:
+
+```bash
+kubectl rollout restart daemonset/boinc -n boinc
+```
+
+To find your weak account key: log into the project website → account settings page
+→ look for "account key" or "weak account key".
+
+---
+
+## Adding a new BOINC project
+
+1. Find the project's BOINC URL and log in to the project website
+2. Copy your **weak account key** from account settings
+3. Edit the Secret:
+   ```bash
+   sops apps/base/boinc/boinc-projects-secret.yaml
+   ```
+   Add a `stringData` key named `account_<project-hostname>.xml`:
+   ```yaml
+   account_setiathome.example.edu.xml: |
+     <account>
+       <master_url>https://setiathome.example.edu/</master_url>
+       <authenticator>YOUR_WEAK_KEY_HERE</authenticator>
+       <project_preferences>
+         <resource_share>100</resource_share>
+       </project_preferences>
+     </account>
+   ```
+4. Add a matching `cp -n` line in the initContainer command in
+   `apps/base/boinc/daemonset.yaml`:
+   ```sh
+   cp -n /boinc-account-init/account_setiathome.example.edu.xml \
+          /var/lib/boinc/account_setiathome.example.edu.xml
+   ```
+5. Commit, push, and restart the DaemonSet:
+   ```bash
+   kubectl rollout restart daemonset/boinc -n boinc
+   ```
+
+---
+
+## Troubleshooting
+
+### BOINC not attached to a project
+
+```bash
+# Verify the initContainer completed (Status should show Terminated with exit code 0)
+kubectl describe pod -n boinc <pod-name> | grep -A 15 "Init Containers:"
+
+# Verify account files were copied to the hostPath volume
+kubectl exec -n boinc $POD -- ls -la /var/lib/boinc/account_*.xml
+
+# Check BOINC logs for authentication errors
+kubectl logs -n boinc $POD | grep -iE "error|failed|invalid|authenticator"
+```
+
+Most common cause: wrong authenticator key in the Secret. Fix with `sops`, commit,
+push, and `kubectl rollout restart daemonset/boinc -n boinc`.
+
+### High CPU temperatures
+
+BOINC uses its full limit (1000m) whenever work units are available. If temperatures
+are consistently above 65°C:
+
+Lower the CPU limit in `apps/base/boinc/daemonset.yaml`:
+
+```yaml
+limits:
+  cpu: 750m   # down from 1000m
+```
+
+Alternatively, set CPU usage preferences on the BOINC project website: account
+settings → computing preferences → "Use at most X% of CPU time".
+
+### initContainer stuck or failed
+
+```bash
+kubectl logs -n boinc <pod-name> -c boinc-account-init
+```
+
+If the initContainer cannot find the Secret volume, Flux has not yet decrypted
+`boinc-projects-secret`. Verify:
+
+```bash
+kubectl get secret boinc-projects-secret -n boinc
+```
+
+If the Secret is missing, check the `apps` Kustomization for SOPS decryption errors:
+
+```bash
+flux get kustomization apps -n flux-system
+kubectl describe kustomization apps -n flux-system | grep -A 10 "Status:"
+```
+
+See `docs/sops-age-secrets.md` for the full SOPS troubleshooting procedure.
+
+### Understanding hostPID
+
+The BOINC DaemonSet sets `hostPID: true`. This allows BOINC to see host-level process
+IDs, which it needs to accurately account for CPU time used by its compute work unit
+processes (which spawn as child processes). Without `hostPID`, BOINC's internal CPU
+accounting would be inaccurate and it would not throttle correctly.
+
+The Kubernetes resource limit (`1000m`) is enforced by the container runtime via
+cgroups regardless of BOINC's internal accounting, so the thermal ceiling holds either
+way. `hostPID` only affects BOINC's visibility, not its actual resource consumption.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,330 @@
+# Key Concepts
+
+What each technology in this cluster is, why it exists, and how it fits together.
+Assumes you know what containers are but are new to Kubernetes and the surrounding ecosystem.
+
+---
+
+## Kubernetes building blocks
+
+Six primitives underpin everything in this cluster.
+
+### Pod
+
+The smallest deployable unit. A Pod is one or more containers that share a network
+interface and filesystem mounts. Pods are ephemeral — when they crash or are
+rescheduled, they are replaced with a new Pod at a new IP address.
+
+### Deployment
+
+Manages a set of identical, stateless Pods. Handles rolling updates, rollbacks, and
+replica count. Use a Deployment when every Pod is interchangeable. (Grafana,
+Prometheus, Envoy Gateway, and most services in this cluster are Deployments.)
+
+### DaemonSet
+
+Runs exactly one Pod on every node. New nodes automatically get the Pod; removed nodes
+lose it. Use a DaemonSet for agents that must run everywhere. (Cilium, Promtail,
+Tetragon, Falco, and BOINC are all DaemonSets in this cluster.)
+
+### StatefulSet
+
+Manages Pods that need a stable identity and dedicated persistent storage. Each Pod
+gets a numbered, stable DNS name (`pod-0`, `pod-1`) and its own PersistentVolume. Use
+for databases and anything that cannot treat all replicas as identical. (Loki and
+Prometheus are StatefulSets here.)
+
+### Namespace
+
+A virtual partition for grouping resources, applying access controls, and scoping
+policies. Not a hard security boundary by itself — Pods in different Namespaces can
+communicate unless a NetworkPolicy prevents it. This cluster uses ~15 Namespaces to
+separate concerns and target Kyverno policies per-namespace.
+
+### Service
+
+A stable network endpoint that routes traffic to a set of Pods. Pods come and go; the
+Service IP and DNS name remain constant. Three types used here:
+
+- **ClusterIP** — reachable only inside the cluster (default)
+- **NodePort** — opens a port on every node, reachable from outside the cluster
+- **Headless** (`clusterIP: None`) — DNS returns individual Pod IPs; used by
+  StatefulSets so each replica is directly addressable by name
+
+### Custom Resource Definition (CRD)
+
+A CRD extends the Kubernetes API with a new resource type. Every `HelmRelease`,
+`Certificate`, `HTTPRoute`, and `ClusterPolicy` you see in this cluster is a CRD —
+installed by a Helm chart and managed like any native Kubernetes object.
+`kubectl get helmreleases -A` works because Flux registered the HelmRelease CRD at
+bootstrap time.
+
+### PersistentVolume / PersistentVolumeClaim (PV / PVC)
+
+A PVC is a request for storage (size, access mode). A PV is the actual storage that
+satisfies it. OpenEBS provisions PVs automatically using node-local directories when a
+PVC is created.
+
+---
+
+## GitOps — Flux
+
+**GitOps** is a deployment model where Git is the single source of truth for what
+should be running in the cluster. You never run `kubectl apply` directly — you commit
+changes to Git and a controller reconciles the cluster to match.
+
+**Flux** is the GitOps controller. It polls the repository every minute, compares Git
+state to cluster state, and applies any difference. Benefits:
+
+- Every change is tracked in Git history — full audit trail
+- Drift is auto-corrected — manual `kubectl` edits are reverted on the next reconcile
+- Rollback = `git revert` + push
+
+**Reconciliation sequence:**
+
+```
+git push
+  └─► Flux GitRepository (polls every 1 min, detects new commit)
+        └─► Flux Kustomization (runs kustomize build, applies manifests)
+              └─► Flux HelmRelease (calls helm upgrade with chart values)
+                    └─► Pods running in the cluster
+```
+
+`flux get all -A` shows the current reconciliation state of every resource:
+
+| Status | Meaning |
+|--------|---------|
+| `READY: True` | Cluster matches Git |
+| `READY: False` + `RECONCILING` | Flux is actively working |
+| `READY: False` + error message | Something failed — read the message |
+
+---
+
+## Helm and HelmRelease
+
+**Helm** is a package manager for Kubernetes. A Helm **chart** is a parameterized
+collection of Kubernetes manifests — like an npm package, but for Kubernetes. You pass
+values overrides and Helm renders the final YAML.
+
+A Flux **HelmRelease** is a CRD that instructs Flux to install and manage a Helm
+chart automatically. Instead of running `helm install` by hand, you commit a
+`HelmRelease` manifest to Git; Flux handles install, upgrade, rollback, and version
+pinning. All chart overrides in this cluster live in the `spec.values` block of the
+relevant `HelmRelease` file.
+
+---
+
+## CNI — Cilium
+
+The **Container Network Interface (CNI)** assigns IP addresses to Pods and routes
+traffic between them. Without a CNI, every Pod is `Pending` — nothing can communicate.
+Cilium is installed before Flux bootstraps so the CNI is live before anything else
+starts.
+
+**Cilium** is an eBPF-based CNI that also replaces kube-proxy:
+
+- Assigns Pod IPs and routes traffic over a VXLAN tunnel between KinD nodes
+- Handles Service load balancing with eBPF programs (faster than iptables)
+- Enforces Kubernetes NetworkPolicy
+- Runs **Hubble**, a built-in observability layer that shows live traffic flows,
+  dropped packets, and per-service metrics without any application code changes
+
+eBPF programs execute inside the Linux kernel without modifying kernel source. Cilium
+uses them to intercept and process every network packet at the lowest possible level.
+
+---
+
+## Service Mesh — Istio
+
+A **service mesh** adds a transparent security and observability layer between
+services. Istio injects a small **Envoy proxy sidecar** container into every
+application Pod. All traffic between Pods flows through these sidecars — never
+directly between application containers.
+
+This provides:
+
+- **mTLS** — every connection between Pods is encrypted and mutually authenticated.
+  Both sides present a certificate before any data is exchanged.
+- **Request metrics** — every call is measured (latency, error rate, throughput)
+  automatically. The Istio Grafana dashboards show this without any code changes.
+- **Distributed tracing** — request spans are exported to Tempo via the OTel Collector
+
+**mTLS in plain language:** Normal TLS only authenticates the server (like HTTPS in a
+browser). Mutual TLS also authenticates the caller. In Istio's mesh, every Pod has a
+short-lived certificate issued by istiod. When Pod A calls Pod B, both verify each
+other's certificate. A compromised Pod cannot impersonate another service because it
+cannot forge that certificate.
+
+In this cluster, Istio is **mesh only** — it handles mTLS between services but does
+not handle traffic entering from outside the cluster. That is Envoy Gateway's job.
+
+---
+
+## Ingress — Envoy Gateway
+
+**Ingress** is the path that gets external HTTP traffic into the cluster. This cluster
+uses the Kubernetes **Gateway API** (the modern replacement for the older `Ingress`
+resource).
+
+**Envoy Gateway** implements Gateway API. You define:
+
+- A `Gateway` CR — "listen for HTTP on port 80"
+- An `HTTPRoute` CR — "route requests with `Host: grafana.local` to the Grafana Service"
+
+Envoy Gateway auto-provisions an Envoy proxy Deployment and NodePort Service. On KinD
+on macOS, an nginx DaemonSet handles the host-to-cluster port mapping (see key design
+decisions in the README for the full explanation).
+
+To expose a new service, create an `HTTPRoute` in its namespace — see the README for
+the template.
+
+---
+
+## Certificate Management — cert-manager
+
+TLS certificates expire. Manual renewal is error-prone and causes outages.
+**cert-manager** automates certificate issuance and renewal. It watches `Certificate`
+CRDs, requests certificates from a configured issuer (self-signed CA, Let's Encrypt,
+Vault, etc.), stores the result in a Kubernetes Secret, and renews automatically before
+expiry.
+
+In this cluster, cert-manager is installed as a dependency for Istio's mTLS
+infrastructure and for future TLS automation needs. The two-phase install (CRDs-only
+HelmRelease first, controller second) eliminates a race condition where the controller
+would start before its own API types were registered.
+
+---
+
+## Persistent Storage — OpenEBS
+
+Kubernetes does not manage storage itself — it delegates to a **CSI (Container Storage
+Interface)** driver. A CSI driver provisions `PersistentVolumes` automatically when a
+`PersistentVolumeClaim` is created.
+
+**OpenEBS localpv** uses node-local directories under `/var/openebs/local/` as
+storage. It is fast and simple, but the data is tied to the node the Pod lands on —
+if that node is removed, the data goes with it. This is acceptable for a homelab
+cluster where durability is not a requirement.
+
+---
+
+## Admission Control — Kyverno
+
+**Admission control** is a webhook that intercepts every object before it reaches the
+Kubernetes API server. Kyverno enforces policies on Pods, Deployments, and other
+resources as they are created or updated.
+
+Two enforcement modes:
+
+- **Audit** — violations are recorded in policy reports but the object is allowed
+  through. Use this to discover problems without breaking things.
+- **Enforce** — violations are rejected at the API server. The Pod never starts.
+
+This cluster uses both modes. `require-resource-limits` and
+`disallow-privilege-escalation` are **Enforce** — Pods without CPU/memory limits are
+rejected at admission. `pod-security-baseline` and `disallow-latest-image-tag` are
+**Audit** — violations are reported but not blocked, allowing infrastructure components
+that legitimately need privileged access to run while their misconfigurations are
+tracked in policy reports.
+
+---
+
+## eBPF Runtime Security — Tetragon
+
+**Tetragon** enforces security policy at the Linux kernel syscall level using eBPF.
+While Kyverno prevents bad Pods from *starting*, Tetragon watches what running Pods
+actually *do*. It can:
+
+- Kill a process that reads a sensitive file
+- Block a network connection to a forbidden destination
+- Record every `execve` syscall (process launch) across the entire cluster
+
+Events are exported as JSON, collected by Promtail, stored in Loki, and visible in
+the **Tetragon kubectl exec audit** Grafana dashboard. TracingPolicies that define what
+to watch live in `infrastructure/configs/tracingpolicies.yaml`.
+
+---
+
+## Behavioral Detection — Falco
+
+**Falco** also uses eBPF but focuses on detection rather than enforcement. It watches
+syscalls and matches them against a library of rules. Suspicious behavior — a container
+spawning a shell, reading `/etc/shadow`, writing to a binary directory — triggers an
+alert.
+
+Alerts flow through **Falcosidekick** (bundled as a subchart) directly to Loki, and
+also appear as Prometheus metrics. The **Falco — Runtime Security** Grafana dashboard
+shows live alerts and historical rule-match rates.
+
+**Tetragon vs Falco:** Tetragon enforces — it can terminate processes and block
+syscalls on the TracingPolicies you define. Falco detects and alerts across a broad
+library of built-in rules but does not block. Running both gives you hard enforcement
+on specific behaviors (Tetragon) and broad suspicious-activity logging (Falco).
+
+---
+
+## Compliance Scanning — Kubescape
+
+**Kubescape** continuously audits the cluster's running configuration against industry
+security frameworks:
+
+- **NSA Kubernetes Hardening Guide** — US National Security Agency's K8s security baseline
+- **MITRE ATT&CK** — maps attacker techniques to misconfigurations (e.g., privilege
+  escalation via hostPath, lateral movement via overpermissioned ServiceAccounts)
+
+Unlike Kyverno (admission-time) and Falco (runtime), Kubescape scans the cluster's
+*current state* and produces a scored compliance report. The **Kubescape Security
+Posture** Grafana dashboard shows control pass/fail rates and trends over time.
+
+Findings that have been reviewed and accepted as intentional are recorded in
+`docs/kubescape-security.md` with rationale so future readers know the decision was
+deliberate.
+
+---
+
+## Secrets Encryption — SOPS + Age
+
+**SOPS** (Secrets OPerationS) encrypts Kubernetes Secret manifests before they are
+committed to Git. **Age** is the encryption backend — a modern replacement for GPG
+with a simpler key format.
+
+Encrypted values look like `ENC[AES256_GCM,data:...,type:str]` in the YAML file.
+Only the `data` and `stringData` fields are encrypted; `kind`, `metadata`, and
+`apiVersion` remain readable. Flux's `kustomize-controller` decrypts secrets in memory
+at reconcile time using a private key stored in the cluster as the `sops-age` secret.
+
+See `docs/sops-age-secrets.md` for the full setup guide and day-to-day workflow.
+
+---
+
+## Voluntary Distributed Computing — BOINC
+
+**BOINC** (Berkeley Open Infrastructure for Network Computing) donates idle CPU cycles
+to scientific research. When the cluster is not under load, BOINC uses spare CPU to
+run computations and submits results to project servers over the internet.
+
+This cluster participates in:
+
+- **Rosetta@Home** — protein structure prediction for medical research
+- **Einstein@Home** — gravitational wave and pulsar detection
+
+BOINC runs as a DaemonSet (one pod per node). It is capped at 1 CPU core to keep peak
+temperatures below 65°C on the passively cooled MacBook Air M5.
+
+See `docs/boinc.md` for operational details, status commands, and how to update
+project credentials.
+
+---
+
+## Demo Namespace — httpbin and load-generator
+
+The `demo` namespace contains two workloads that exist purely to generate traffic
+through the Istio mesh:
+
+- **httpbin** (`kennethreitz/httpbin`) — an HTTP echo server that responds to any
+  GET/POST request. Not a real application — it is a convenient traffic target.
+- **load-generator** (`curlimages/curl`) — sends requests to httpbin every 5 seconds,
+  producing a continuous stream of HTTP metrics across the mesh.
+
+Without this traffic, the Istio Grafana dashboards (Mesh, Service, Workload) show
+empty graphs. The load-generator ensures those dashboards always have meaningful data.

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -1,7 +1,7 @@
 # Troubleshooting Guide
 
 Cluster: `flux-kind` · KinD 1.35.0 · 1 control-plane + 2 workers
-Stack: Flux CD · Cilium 1.17 · Hubble · cert-manager 1.17 · OpenEBS 4.2 · Istio 1.26 (mesh only) · Gateway API v1.2.1 · Envoy Gateway 1.4 · Tetragon 1.7 · Kyverno 3 · Kubescape 1.40 · Falco 8 · kube-prometheus-stack 72 · Grafana 8 · Grafana Tempo 1 · OpenTelemetry Collector 0 · SOPS + Age
+Stack: Flux CD · Cilium 1.17 · Hubble · cert-manager 1.17 · OpenEBS 4.2 · Istio 1.26 (mesh only) · Gateway API v1.2.1 · Envoy Gateway 1.4 · Tetragon 1.7 · Kyverno 3 · Kubescape 1.40 · Falco 8 · kube-prometheus-stack 72 · Grafana 10 (app 12) · Grafana Tempo 1 · OpenTelemetry Collector 0 · BOINC · SOPS + Age
 
 ---
 
@@ -29,6 +29,7 @@ Stack: Flux CD · Cilium 1.17 · Hubble · cert-manager 1.17 · OpenEBS 4.2 · I
 19. [Kubescape](#19-kubescape)
 20. [SOPS + Age](#20-sops--age)
 21. [Common issues](#21-common-issues)
+22. [BOINC](#22-boinc)
 
 ---
 
@@ -1444,3 +1445,61 @@ kubectl logs -n falco -l app.kubernetes.io/name=falco --since=10m \
 ```
 
 **Root cause if BTF is unavailable:** `modern_ebpf` requires kernel BTF support. KinD nodes on Linux expose the host kernel BTF at `/sys/kernel/btf/vmlinux`. If the host kernel predates 5.8 or was built without `CONFIG_DEBUG_INFO_BTF`, Falco will fail to load. Upgrade the host kernel or switch to a KinD node image with a newer kernel.
+
+---
+
+## 22. BOINC
+
+See `docs/boinc.md` for full operational detail. Quick reference below.
+
+### BOINC status
+
+```bash
+# Pods — one per node, all should be Running
+kubectl get pods -n boinc -o wide
+
+# Recent logs — look for project attach messages on first start
+kubectl logs -n boinc -l app=boinc --tail=50
+```
+
+### Check project attachment
+
+```bash
+POD=$(kubectl get pod -n boinc -l app=boinc -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n boinc $POD -- boinccmd --get_project_status
+```
+
+Expected: two projects listed — `https://boinc.bakerlab.org/rosetta/` and
+`https://einstein.phys.uwm.edu/`.
+
+### Update credentials
+
+```bash
+# Edit and re-encrypt in one step
+sops apps/base/boinc/boinc-projects-secret.yaml
+
+# After committing and pushing, restart to pick up new credentials
+kubectl rollout restart daemonset/boinc -n boinc
+```
+
+### BOINC logs
+
+```bash
+kubectl logs -n boinc -l app=boinc --tail=50
+
+# Filter to errors only
+kubectl logs -n boinc -l app=boinc | grep -iE "error|failed|invalid"
+```
+
+### initContainer logs (credential copy step)
+
+```bash
+kubectl logs -n boinc <pod-name> -c boinc-account-init
+```
+
+If the initContainer failed, verify the Secret was decrypted by Flux:
+
+```bash
+kubectl get secret boinc-projects-secret -n boinc
+# If missing, check: flux get kustomization apps -n flux-system
+```


### PR DESCRIPTION
New files:
- docs/concepts.md — explains every technology (K8s primitives, GitOps, Cilium, Istio, Envoy Gateway, cert-manager, OpenEBS, Kyverno, Tetragon, Falco, Kubescape, SOPS, BOINC, demo namespace) for readers new to K8s
- docs/boinc.md — BOINC operational guide: architecture, initContainer pattern, status commands, credential updates, adding projects, troubleshooting

README.md:
- Add Documentation index table linking all docs
- Add "How changes flow" GitOps workflow section with numbered sequence
- Add "After bootstrap — Day 1 checklist" with 10 ordered verification steps
- Add Container images table (directly-referenced images outside Helm charts)
- Add BOINC row to Deployed components table
- Fix stale Grafana version: 8.x → 10.x (app 12.x) in both tables

docs/troubleshooting-guide.md:
- Add §22 BOINC with status, project attachment, credential update, and log commands
- Update stack header: Grafana 8 → Grafana 10 (app 12), add BOINC
- Add BOINC entry to table of contents