### PR TITLE
docs: update version strings to match running cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,26 +165,26 @@ flux-system (GitRepository)
 
 | Component | Chart / Source | Version | Namespace | Notes |
 |---|---|---|---|---|
-| Cilium CNI | cilium/cilium | 1.17.x | kube-system | |
-| Hubble Relay | (bundled with Cilium) | 1.17.x | kube-system | |
+| Cilium CNI | cilium/cilium | 1.19.x | kube-system | |
+| Hubble Relay | (bundled with Cilium) | 1.19.x | kube-system | |
 | Hubble UI | (bundled with Cilium) | 0.13.1 | kube-system | disabled by default; enable via `hubble.ui.enabled: true` in `cilium.yaml` |
-| cert-manager | cert-manager/cert-manager | v1.17.x | cert-manager | |
+| cert-manager | cert-manager/cert-manager | v1.20.x | cert-manager | |
 | OpenEBS localpv | openebs/openebs | 4.2.0 | openebs | |
-| istio-base | istio/base | 1.26.x | istio-system | |
-| istiod | istio/istiod | 1.26.x | istio-system | |
+| istio-base | istio/base | 1.30.x | istio-system | |
+| istiod | istio/istiod | 1.30.x | istio-system | |
 | Gateway API CRDs | kubernetes-sigs/gateway-api | v1.2.1 | (cluster-scoped) | |
 | Envoy Gateway | envoy-gateway/gateway | 1.4.x | envoy-gateway-system | |
 | Envoy Gateway data-plane | gatewayClassName: eg | 1.4.x | envoy-ingress | |
 | kube-prometheus-stack | prometheus-community/kube-prometheus-stack | 86.x | observability | |
 | Grafana | grafana/grafana | 10.x (app 12.x) | observability | |
-| Loki | grafana/loki | 6.x | observability | |
+| Loki | grafana/loki | 7.x | observability | |
 | Promtail | grafana/promtail | 6.x | observability | |
 | Grafana Tempo | grafana/tempo | 1.x | observability | Single-binary mode; trace backend for the OTel pipeline |
 | OpenTelemetry Collector | open-telemetry/opentelemetry-collector | 0.x | observability | contrib distribution; OTLP ingress → Tempo export; Istio sidecar disabled |
 | Tetragon | cilium/tetragon | 1.7.x | tetragon | |
 | Kyverno | kyverno/kyverno | 3.x | kyverno | |
 | Kubescape | kubescape/kubescape-operator | 1.40.x | kubescape | NSA + MITRE continuous scan; vulnerability scan disabled for KinD |
-| Falco + Falcosidekick | falcosecurity/falco | 8.x | falco | |
+| Falco + Falcosidekick | falcosecurity/falco | 9.x | falco | |
 | demo (httpbin) | kennethreitz/httpbin | @sha256 digest pin | demo | No versioned tags published; pinned by digest |
 | BOINC | boinc/client | arm64v8 | boinc | Voluntary compute — Rosetta@Home + Einstein@Home; capped at 1 CPU core for thermal management |
 | Renovate Bot | renovatebot/renovate | (GitHub App) | — | Automated dependency PRs for Helm charts, images, GitHub Actions, and CI tool pins |
@@ -198,10 +198,10 @@ version constraint in the HelmRelease.
 | Image | Tag / Digest | File | Purpose |
 |-------|-------------|------|---------|
 | `boinc/client` | `arm64v8` | `apps/base/boinc/daemonset.yaml` | BOINC compute client (ARM64-native) |
-| `busybox` | `1.37` | `apps/base/boinc/daemonset.yaml` | initContainer: copies account XML credentials to hostPath |
+| `busybox` | `1.38` | `apps/base/boinc/daemonset.yaml` | initContainer: copies account XML credentials to hostPath |
 | `kennethreitz/httpbin` | `@sha256:599f…` | `apps/base/demo/httpbin.yaml` | HTTP echo server — mesh traffic target |
-| `curlimages/curl` | `8.7.1` | `apps/base/demo/load-generator.yaml` | Load generator: curl loop → httpbin every 5 s |
-| `nginx` | `1.27-alpine` | `apps/overlays/kind/istio/nodeport-proxy.yaml` | KinD ingress workaround: proxies host port 8888 → Envoy ClusterIP |
+| `curlimages/curl` | `8.20.0` | `apps/base/demo/load-generator.yaml` | Load generator: curl loop → httpbin every 5 s |
+| `nginx` | `1.31-alpine` | `apps/overlays/kind/istio/nodeport-proxy.yaml` | KinD ingress workaround: proxies host port 8888 → Envoy ClusterIP |
 | `falcosecurity/event-generator` | `0.13.0` | `tests/falco/event-generator.yaml` | Falco live detection test job |
 
 ## Version compatibility
@@ -211,18 +211,18 @@ The versions below were validated together. When upgrading a component, check co
 | Component | Validated version | Constrained by |
 |---|---|---|
 | Kubernetes (KinD node) | v1.35.0 | `K8S_VER` in `versions.env` |
-| Cilium | 1.17.x | `cilium.yaml` chart constraint + `versions.env` |
-| Istio | 1.26.x | `istio.yaml` chart constraint + `versions.env` |
+| Cilium | 1.19.x | `cilium.yaml` chart constraint + `versions.env` |
+| Istio | 1.30.x | `istio.yaml` chart constraint + `versions.env` |
 | Envoy Gateway | 1.4.x (v1.4.6) | `envoy-gateway.yaml` + `versions.env` |
 | Gateway API CRDs | v1.2.1 | hardcoded in `setup-fluxcd-gitops-kind-multinode.sh` step 4 |
 | kube-prometheus-stack | 86.x | `prometheus/helmrelease.yaml` |
-| Loki | 6.x | `loki/helmrelease.yaml` |
+| Loki | 7.x | `loki/helmrelease.yaml` |
 | Grafana | 10.x (app 12.x) | `grafana/helmrelease.yaml` |
 | Grafana Tempo | 1.x | `tempo/helmrelease.yaml` |
 | OpenTelemetry Collector | 0.x | `opentelemetry/helmrelease.yaml` |
 | Kyverno | 3.x | `kyverno.yaml` |
 | Kubescape | 1.40.x | `kubescape.yaml` |
-| Falco | 8.x | `falco.yaml` |
+| Falco | 9.x | `falco.yaml` |
 | Tetragon | 1.7.x | `tetragon.yaml` |
 
 All version pins shared between the Makefile and setup script are sourced from `versions.env` at the repo root — bump them there and both consumers update.

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -1,7 +1,7 @@
 # Troubleshooting Guide
 
 Cluster: `flux-kind` · KinD 1.35.0 · 1 control-plane + 2 workers
-Stack: Flux CD · Cilium 1.17 · Hubble · cert-manager 1.17 · OpenEBS 4.2 · Istio 1.26 (mesh only) · Gateway API v1.2.1 · Envoy Gateway 1.4 · Tetragon 1.7 · Kyverno 3 · Kubescape 1.40 · Falco 8 · kube-prometheus-stack 72 · Grafana 10 (app 12) · Grafana Tempo 1 · OpenTelemetry Collector 0 · BOINC · SOPS + Age
+Stack: Flux CD · Cilium 1.19 · Hubble · cert-manager 1.20 · OpenEBS 4.2 · Istio 1.30 (mesh only) · Gateway API v1.2.1 · Envoy Gateway 1.4 · Tetragon 1.7 · Kyverno 3 · Kubescape 1.40 · Falco 9 · kube-prometheus-stack 86 · Grafana 10 (app 12) · Grafana Tempo 1 · OpenTelemetry Collector 0 · BOINC · SOPS + Age
 
 ---
 
@@ -493,8 +493,8 @@ kubectl create namespace istio-test
 kubectl label namespace istio-test istio-injection=enabled
 
 # Deploy client (sleep) and server (httpbin)
-kubectl apply -n istio-test -f https://raw.githubusercontent.com/istio/istio/release-1.26/samples/sleep/sleep.yaml
-kubectl apply -n istio-test -f https://raw.githubusercontent.com/istio/istio/release-1.26/samples/httpbin/httpbin.yaml
+kubectl apply -n istio-test -f https://raw.githubusercontent.com/istio/istio/release-1.30/samples/sleep/sleep.yaml
+kubectl apply -n istio-test -f https://raw.githubusercontent.com/istio/istio/release-1.30/samples/httpbin/httpbin.yaml
 
 # Wait for 2/2 — the /2 confirms the Envoy sidecar was injected
 kubectl wait --for=condition=ready pod -l app=sleep -n istio-test --timeout=90s

--- a/images/architecture.svg
+++ b/images/architecture.svg
@@ -56,7 +56,7 @@
   <!-- Row 1 ─────────────────────────────────────────────── -->
   <!-- Cilium -->
   <rect x="54" y="253" width="258" height="90" rx="8" fill="white" stroke="#C2410C" stroke-width="2"/>
-  <text x="183" y="273" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="13" font-weight="700" fill="#C2410C">Cilium 1.17.x</text>
+  <text x="183" y="273" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="13" font-weight="700" fill="#C2410C">Cilium 1.19.x</text>
   <line x1="62" y1="280" x2="304" y2="280" stroke="#C2410C" stroke-width="0.75" opacity="0.35"/>
   <text x="183" y="296" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">namespace: kube-system</text>
   <text x="183" y="310" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">kubeProxyReplacement · VXLAN tunnel</text>
@@ -65,7 +65,7 @@
 
   <!-- cert-manager -->
   <rect x="332" y="253" width="258" height="90" rx="8" fill="white" stroke="#15803D" stroke-width="2"/>
-  <text x="461" y="273" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="13" font-weight="700" fill="#15803D">cert-manager v1.17.x</text>
+  <text x="461" y="273" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="13" font-weight="700" fill="#15803D">cert-manager v1.20.x</text>
   <line x1="340" y1="280" x2="582" y2="280" stroke="#15803D" stroke-width="0.75" opacity="0.35"/>
   <text x="461" y="296" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">namespace: cert-manager</text>
   <text x="461" y="310" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">two-phase CRD install</text>
@@ -83,7 +83,7 @@
 
   <!-- Istio -->
   <rect x="888" y="253" width="258" height="90" rx="8" fill="white" stroke="#15803D" stroke-width="2"/>
-  <text x="1017" y="273" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="13" font-weight="700" fill="#15803D">Istio 1.26.x</text>
+  <text x="1017" y="273" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="13" font-weight="700" fill="#15803D">Istio 1.30.x</text>
   <line x1="896" y1="280" x2="1138" y2="280" stroke="#15803D" stroke-width="0.75" opacity="0.35"/>
   <text x="1017" y="296" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">namespace: istio-system</text>
   <text x="1017" y="310" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">istio-base + istiod · PERMISSIVE mesh</text>
@@ -120,7 +120,7 @@
 
   <!-- Falco -->
   <rect x="720" y="357" width="206" height="90" rx="8" fill="white" stroke="#B91C1C" stroke-width="2"/>
-  <text x="823" y="377" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="12" font-weight="700" fill="#B91C1C">Falco 8.x</text>
+  <text x="823" y="377" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="12" font-weight="700" fill="#B91C1C">Falco 9.x</text>
   <line x1="728" y1="384" x2="918" y2="384" stroke="#B91C1C" stroke-width="0.75" opacity="0.35"/>
   <text x="823" y="400" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9.5" fill="#475569">namespace: falco</text>
   <text x="823" y="414" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9.5" fill="#475569">modern_ebpf · runtime detect</text>
@@ -155,7 +155,7 @@
   <rect x="55" y="550" width="136" height="54" rx="6" fill="#EFF6FF" stroke="#1D4ED8" stroke-width="1.25"/>
   <text x="123" y="568" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" font-weight="700" fill="#1D4ED8">Prometheus</text>
   <text x="123" y="583" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">kube-prometheus-stack</text>
-  <text x="123" y="597" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">72.x · dependsOn: openebs</text>
+  <text x="123" y="597" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">86.x · dependsOn: openebs</text>
 
   <!-- AlertManager chip -->
   <rect x="203" y="550" width="132" height="54" rx="6" fill="#EFF6FF" stroke="#1D4ED8" stroke-width="1.25"/>
@@ -166,7 +166,7 @@
   <!-- Loki chip -->
   <rect x="347" y="550" width="120" height="54" rx="6" fill="#EFF6FF" stroke="#1D4ED8" stroke-width="1.25"/>
   <text x="407" y="568" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" font-weight="700" fill="#1D4ED8">Loki</text>
-  <text x="407" y="583" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">grafana/loki 6.x</text>
+  <text x="407" y="583" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">grafana/loki 7.x</text>
   <text x="407" y="597" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">SingleBinary · 5 Gi PVC</text>
 
   <!-- Promtail chip -->

--- a/images/flow.svg
+++ b/images/flow.svg
@@ -69,7 +69,7 @@
   <rect x="40" y="380" width="150" height="218" rx="8" fill="white" stroke="#C2410C" stroke-width="2"/>
   <text x="115" y="400" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" font-weight="700" fill="#C2410C">Cilium HR</text>
   <line x1="48" y1="407" x2="182" y2="407" stroke="#C2410C" stroke-width="0.75" opacity="0.4"/>
-  <text x="115" y="422" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">1.17.x</text>
+  <text x="115" y="422" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">1.19.x</text>
   <text x="115" y="436" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">kube-system</text>
   <text x="115" y="452" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">no dependsOn</text>
   <text x="115" y="466" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" font-style="italic" fill="#94A3B8">(root anchor)</text>
@@ -177,7 +177,7 @@
   <!-- kube-prometheus-stack -->
   <rect x="38" y="675" width="155" height="90" rx="6" fill="white" stroke="#1D4ED8" stroke-width="1.5"/>
   <text x="115" y="695" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#1D4ED8">kube-prometheus-stack HR</text>
-  <text x="115" y="710" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">72.x · dependsOn: openebs</text>
+  <text x="115" y="710" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">86.x · dependsOn: openebs</text>
   <text x="115" y="723" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Prometheus + AlertManager</text>
   <text x="115" y="749" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" font-style="italic" fill="#94A3B8">root dep for observability</text>
 


### PR DESCRIPTION
Cilium 1.17→1.19, Istio 1.26→1.30, cert-manager 1.17→1.20, kube-prometheus-stack 72→86, Falco 8→9, Loki 6→7,
busybox 1.37→1.38, curl 8.7.1→8.20.0, nginx 1.27-alpine→1.31-alpine.

Updates README.md (Deployed components + Container images + Version compatibility tables), docs/troubleshooting-guide.md (stack header and Istio sample manifest URLs), images/architecture.svg, and images/flow.svg.