### PR TITLE
feat(infra): add Metrics Server for metrics.k8s.io API

### DIFF
--- a/apps/base/prometheus/helmrelease.yaml
+++ b/apps/base/prometheus/helmrelease.yaml
@@ -425,3 +425,25 @@ spec:
                 target_label: namespace
               - source_labels: [__meta_kubernetes_pod_name]
                 target_label: pod
+
+          # Metrics Server self-metrics: API request latency, cache hits, scrape
+          # duration. ServiceMonitor CRD circular-dependency avoided via pod-role
+          # discovery — same pattern as other infrastructure tools.
+          - job_name: metrics-server
+            kubernetes_sd_configs:
+              - role: pod
+                namespaces:
+                  names:
+                    - metrics-server
+            relabel_configs:
+              - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+                action: keep
+                regex: metrics-server
+              - source_labels: [__address__]
+                target_label: __address__
+                regex: (.+):\d+
+                replacement: $1:8080
+              - source_labels: [__meta_kubernetes_namespace]
+                target_label: namespace
+              - source_labels: [__meta_kubernetes_pod_name]
+                target_label: pod

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - kyverno.yaml
   - kubescape.yaml
   - falco.yaml
+  - metrics-server.yaml

--- a/infrastructure/controllers/metrics-server.yaml
+++ b/infrastructure/controllers/metrics-server.yaml
@@ -1,0 +1,83 @@
+---
+# Metrics Server implements the Kubernetes Resource Metrics API
+# (metrics.k8s.io/v1beta1), powering kubectl top and HPA/VPA.
+# This is separate from Prometheus: Prometheus stores long-term time-series;
+# Metrics Server provides a live in-memory window (15 s) consumed by the API server.
+#
+# --kubelet-insecure-tls: KinD kubelet serving certs are self-signed.
+#   In a production cluster, remove this flag and provide a proper kubelet CA.
+# --kubelet-preferred-address-types: KinD nodes are reachable only via InternalIP.
+#
+# Injection disabled: Metrics Server registers an API extension with the
+# Kubernetes API server, which connects without an Istio sidecar. Enabling
+# injection in this namespace would require a port-level DISABLE exception —
+# disabling it here is simpler and consistent with all other infrastructure controllers.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metrics-server
+  labels:
+    istio-injection: disabled
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: metrics-server
+  namespace: flux-system
+spec:
+  interval: 1h
+  targetNamespace: metrics-server
+  dependsOn:
+    - name: cilium
+      namespace: flux-system
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  chart:
+    spec:
+      chart: metrics-server
+      version: "3.x"
+      sourceRef:
+        kind: HelmRepository
+        name: metrics-server
+        namespace: flux-system
+      interval: 24h
+  values:
+    args:
+      - --kubelet-insecure-tls
+      - --kubelet-preferred-address-types=InternalIP
+
+    # Exposes /metrics on port 8080; scraped by Prometheus via additionalScrapeConfigs.
+    metrics:
+      enabled: true
+
+    # Kyverno enforce policy: require-resource-limits applies to this namespace
+    # (metrics-server is not in the exclusion list).
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+    # Kyverno enforce policy: disallow-privilege-escalation applies here.
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities:
+        drop: [ALL]
+
+    # Single replica for KinD. For production HA: replicas: 2 + podDisruptionBudget.enabled: true
+    replicas: 1
+    podDisruptionBudget:
+      enabled: false

--- a/infrastructure/controllers/repositories.yaml
+++ b/infrastructure/controllers/repositories.yaml
@@ -101,3 +101,12 @@ metadata:
 spec:
   interval: 24h
   url: https://open-telemetry.github.io/opentelemetry-helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: metrics-server
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://kubernetes-sigs.github.io/metrics-server/


### PR DESCRIPTION
Registers metrics.k8s.io/v1beta1 so kubectl top and HPA/VPA work. Metrics Server is separate from Prometheus — it serves a live 15s in-memory window to the API server; Prometheus handles long-term storage.

- New HelmRepository: kubernetes-sigs/metrics-server
- New HelmRelease in metrics-server namespace (istio-injection: disabled)
- KinD flags: --kubelet-insecure-tls, --kubelet-preferred-address-types=InternalIP
- Security: allowPrivilegeEscalation=false, readOnlyRootFilesystem, runAsNonRoot, capabilities dropped, resource limits set (satisfies Kyverno enforce policies)
- Prometheus additionalScrapeConfig on port 8080 for self-metrics