### PR TITLE
ci(renovate): harden workflow with SHA pins, least-privilege permissi…

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,26 @@
+name: Renovate
+on:
+  workflow_dispatch: # Allows manual trigger
+  schedule:
+    - cron: '0 0 * * *' # Automatically runs every day at midnight
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@0c8490ff7b483cba30854febf81dba51db448a60 # v41.0.1
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
…ons, and concurrency guard

Fix wrong configurationFile path (.renovate.json → renovate.json), pin both actions to immutable commit SHAs, add minimal permissions block, and add a concurrency group to prevent overlapping Renovate runs.