### PR TITLE
ci(validate): bump actions/checkout and upload-artifact to Node.js 24

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -8,7 +8,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@v2.8.8
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload Kubescape scan results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kubescape-results
           path: kubescape-results.xml


### PR DESCRIPTION
checkout v4→v6.0.3, upload-artifact v4→v7.0.1 — both SHA-pinned. Resolves Node.js 20 deprecation ahead of the June 16 deadline.