### PR TITLE
ci(validate): pass --offline to kubescape scan to suppress network wa…

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -66,6 +66,7 @@ jobs:
       - name: Kubescape offline scan (NSA + MITRE)
         run: |
           kubescape scan framework nsa,mitre \
+            --offline \
             --format junit \
             --output kubescape-results.xml \
             --compliance-threshold 80 \

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install Kubescape CLI
         env:
-          KUBESCAPE_VERSION: v4.0.8
+          KUBESCAPE_VERSION: v4.0.9
         run: |
           VERSION_CLEAN="${KUBESCAPE_VERSION#v}"
           ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
@@ -63,10 +63,13 @@ jobs:
           chmod +x kubescape
           sudo mv kubescape /usr/local/bin/kubescape
 
+      - name: Download Kubescape artifacts
+        continue-on-error: true
+        run: kubescape download artifacts
+
       - name: Kubescape offline scan (NSA + MITRE)
         run: |
           kubescape scan framework nsa,mitre \
-            --offline \
             --format junit \
             --output kubescape-results.xml \
             --compliance-threshold 80 \


### PR DESCRIPTION
…rnings

The regolibrary/releases/download/v2 endpoint returns HTTP 500, causing four noisy warnings per run. Adding --offline tells Kubescape to use policies bundled with the binary and skip all network fetches. Policy version stays reproducible and advances automatically when the binary is bumped.