### PR TITLE
feat(openebs): upgrade to 4.x and re-enable Renovate tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ flux-system (GitRepository)
 | Hubble Relay | (bundled with Cilium) | 1.19.x | kube-system | |
 | Hubble UI | (bundled with Cilium) | 0.13.1 | kube-system | disabled by default; enable via `hubble.ui.enabled: true` in `cilium.yaml` |
 | cert-manager | cert-manager/cert-manager | v1.20.x | cert-manager | |
-| OpenEBS localpv | openebs/openebs | 4.2.0 | openebs | |
+| OpenEBS localpv | openebs/openebs | 4.x | openebs | |
 | istio-base | istio/base | 1.30.x | istio-system | |
 | istiod | istio/istiod | 1.30.x | istio-system | |
 | Gateway API CRDs | kubernetes-sigs/gateway-api | v1.2.1 | (cluster-scoped) | |

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -39,7 +39,6 @@ Kyverno tests + Kubescape scan) must pass. If CI is red, Renovate does not merge
 |---------|--------|
 | `boinc/client` | `arm64v8` is a Docker manifest architecture alias, not a version tag — there is no "newer" to detect |
 | `kennethreitz/httpbin` | No versioned tags published; manifest pins the image by digest. Digest bumps produce noise with no upgrade signal |
-| `openebs` | The chart's pre-upgrade Job references `bitnami/kubectl:1.25.15` which no longer exists on Docker Hub. Any chart upgrade triggers the broken hook |
 
 ---
 

--- a/infrastructure/controllers/openebs.yaml
+++ b/infrastructure/controllers/openebs.yaml
@@ -29,7 +29,7 @@ spec:
   chart:
     spec:
       chart: openebs
-      version: "4.2.0"
+      version: "4.x"
       sourceRef:
         kind: HelmRepository
         name: openebs

--- a/renovate.json
+++ b/renovate.json
@@ -100,12 +100,6 @@
       "enabled": false
     },
     {
-      "description": "Disable OpenEBS — pre-upgrade hook references bitnami/kubectl:1.25.15 which no longer exists on Docker Hub; any upgrade triggers the broken hook",
-      "matchManagers": ["flux"],
-      "matchPackageNames": ["openebs"],
-      "enabled": false
-    },
-    {
       "description": "Patch tier: group container image patch updates and automerge after CI passes",
       "matchManagers": ["kubernetes"],
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
The pre-upgrade hook that referenced bitnami/kubectl:1.25.15 (deleted from Docker Hub) was fixed upstream in two stages:
- v4.3.3: hook now only fires on v3→v4 upgrades (v4→v4 skips it entirely)
- v4.4.0: image replaced with openebs/kubectl, now maintained by the project

Relaxes the exact pin from "4.2.0" to the "4.x" range constraint (consistent with all other HelmReleases in this repo) so Flux resolves the latest 4.x chart (currently 4.5.0). Removes the Renovate disabled packageRule so future minor bumps open a PR for human review as normal.