### PR TITLE
fix(openebs): disable built-in loki and alloy subcharts added in 4.3+

### DIFF
--- a/infrastructure/controllers/openebs.yaml
+++ b/infrastructure/controllers/openebs.yaml
@@ -37,6 +37,8 @@ spec:
       interval: 24h
   values:
     # OpenEBS 4.x uses subcharts. For KinD, only localpv-provisioner is needed.
+    # loki/alloy/minio are part of the built-in observability stack added in 4.3+;
+    # this cluster has its own Loki stack in the observability namespace.
     engines:
       replicated:
         mayastor:
@@ -48,9 +50,9 @@ spec:
           enabled: false
     mayastor:
       enabled: false
-    loki-stack:
+    loki:
       enabled: false
-    obs-callhome:
+    alloy:
       enabled: false
     localpv-provisioner:
       enabled: true


### PR DESCRIPTION
OpenEBS 4.3+ ships loki/alloy/minio as an opt-out observability stack. The old loki-stack and obs-callhome keys are gone; the new keys are loki.enabled and alloy.enabled (both default true). Without this fix Loki tries to provision PVCs before OpenEBS is ready, deadlocking the install. This cluster has its own Loki in the observability namespace.