### PR TITLE
fix(makefile): suppress grep filename prefix in help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ BOOTSTRAP_IMAGES := \
 
 # ── Help ──────────────────────────────────────────────────────────────────────
 help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
 	  | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
 # ── Cluster lifecycle ─────────────────────────────────────────────────────────


### PR DESCRIPTION
include versions.env adds versions.env to MAKEFILE_LIST, causing grep to prefix matches with the filename. -h suppresses that so awk 67801 captures the target name instead of 'Makefile'.