### PR TITLE
fix(renovate): correct workflow permissions and document required PAT…

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -8,9 +8,13 @@ concurrency:
   group: renovate
   cancel-in-progress: false
 
+# These permissions apply to GITHUB_TOKEN only. RENOVATE_TOKEN (a PAT) is
+# controlled by the scopes set when the token was created — see the comment
+# on the "Self-hosted Renovate" step below for required PAT scopes.
 permissions:
-  contents: read
-  pull-requests: write
+  contents: write      # push renovate/* branches
+  pull-requests: write # open PRs
+  issues: write        # read and update the Dependency Dashboard issue
 
 jobs:
   renovate:
@@ -20,7 +24,13 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@0c8490ff7b483cba30854febf81dba51db448a60 # v41.0.1
+        # RENOVATE_TOKEN must be a PAT with the following scopes:
+        #   Classic PAT : repo, workflow
+        #   Fine-grained: contents:write, issues:write, pull-requests:write,
+        #                 workflows:write, metadata:read
+        # The `workflow` / `workflows:write` scope is mandatory — without it
+        # GitHub silently rejects any push that touches .github/workflows/*.
+        uses: renovatebot/github-action@a7b39bb5a4c15a2c0aa3025ac7a1a77b91afec5d # v41.0.14
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
… scopes

- permissions: contents:read → write (push renovate/* branches)
- permissions: add issues:write (read/update Dependency Dashboard issue)
- Upgrade renovatebot/github-action v41.0.1 → v41.0.14
- Document that RENOVATE_TOKEN needs `workflow` scope (classic PAT) or `workflows:write` (fine-grained PAT); without it GitHub silently rejects pushes to .github/workflows/* and no PRs are created