### PR TITLE
fix(renovate): pass RENOVATE_REPOSITORIES and fix RE2 regex error

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -31,6 +31,10 @@ jobs:
         # The `workflow` / `workflows:write` scope is mandatory — without it
         # GitHub silently rejects any push that touches .github/workflows/*.
         uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd # v46.1.15
+        env:
+          # v46+ no longer auto-detects the repository from GITHUB_REPOSITORY;
+          # must be set explicitly so Renovate knows which repo to process.
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -12,10 +12,14 @@
 
   "kubernetes": {
     "managerFilePatterns": [
-      "/(^|/)apps/(?!base/kyverno/tests).+\\.yaml$/",
+      "/(^|/)apps/.+\\.yaml$/",
       "/(^|/)infrastructure/.+\\.yaml$/"
     ]
   },
+
+  "ignorePaths": [
+    "apps/base/kyverno/tests/**"
+  ],
 
   "customManagers": [
     {


### PR DESCRIPTION
Two issues found in live run logs:

1. 'No repositories found' — v46+ of renovatebot/github-action no longer auto-detects the repo from GITHUB_REPOSITORY. Add RENOVATE_REPOSITORIES env var so Renovate knows which repo to process.

2. Config validation error — negative lookahead (?!base/kyverno/tests) in kubernetes.managerFilePatterns is not supported by RE2. Replace with top-level ignorePaths which Renovate applies across all managers.