### PR TITLE
fix: correct falcosidekick Loki URL and disable trivy node-collector

### DIFF
--- a/infrastructure/controllers/falco.yaml
+++ b/infrastructure/controllers/falco.yaml
@@ -119,7 +119,7 @@ spec:
       replicaCount: 1
       config:
         loki:
-          hostport: "http://loki.observability.svc.cluster.local:3100"
+          hostport: "http://observability-loki.observability.svc.cluster.local:3100"
           tenant: ""
           format: json
       resources:

--- a/infrastructure/controllers/trivy.yaml
+++ b/infrastructure/controllers/trivy.yaml
@@ -77,6 +77,11 @@ spec:
       # break the same circular dependency as other infrastructure tools).
       metricsBindAddress: ":8080"
 
+      # Disable infrastructure assessment scanning — the node-collector
+      # Deployment it creates has cloud-node affinity rules that never
+      # match KinD worker nodes, leaving a pod permanently Pending.
+      infraAssessmentScannerEnabled: false
+
     # Security context for the operator container.
     # Kyverno enforce policy (disallow-privilege-escalation) applies.
     securityContext:


### PR DESCRIPTION
falcosidekick: Flux names Helm releases as {targetNamespace}-{name}, so the Loki service is observability-loki, not loki. The wrong hostname caused every Falco alert to be silently dropped via DNS NXDOMAIN.

trivy-operator: infraAssessmentScannerEnabled defaults to true and creates a node-collector Deployment with cloud-node affinity that can never schedule on KinD workers, leaving a pod permanently Pending.