### PR TITLE
fix(netpol): correct Envoy Gateway NetworkPolicies and add Prometheus mTLS exception

### DIFF
--- a/apps/base/istio/peerauthentication.yaml
+++ b/apps/base/istio/peerauthentication.yaml
@@ -90,6 +90,24 @@ spec:
     "3100":
       mode: PERMISSIVE
 ---
+# Prometheus: allow plain text on port 9090.
+# Envoy Gateway (no Istio sidecar) routes prometheus.local here and sends
+# plain text. All other ports on Prometheus remain STRICT.
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: prometheus-port-9090
+  namespace: observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  mtls:
+    mode: STRICT
+  portLevelMtls:
+    "9090":
+      mode: PERMISSIVE
+---
 # Alertmanager: allow plain text on port 9093.
 # Prometheus operator configures Prometheus to send alerts to Alertmanager
 # via the headless alertmanager-operated service (resolves to pod IPs).

--- a/infrastructure/controllers/envoy-gateway.yaml
+++ b/infrastructure/controllers/envoy-gateway.yaml
@@ -8,7 +8,8 @@ metadata:
   labels:
     istio-injection: disabled
 ---
-# Envoy Gateway data-plane (auto-provisioned Envoy proxy pods) runs in envoy-ingress.
+# envoy-ingress holds only the nginx nodeport-proxy DaemonSet (KinD port-mapping shim).
+# Envoy Gateway auto-provisions the data-plane proxy pod in envoy-gateway-system (1.4.x).
 # Injection disabled: Envoy Gateway manages its own Envoy proxies; Istio sidecar
 # injection would conflict with the gateway container lifecycle.
 apiVersion: v1
@@ -127,26 +128,51 @@ spec:
     - to:
         - podSelector: {}
 ---
-# The controller pushes xDS configuration to Envoy proxy pods in envoy-ingress
-# on port 18000.
+# The nodeport-proxy (envoy-ingress) uses hostNetwork: true, so its traffic originates
+# from the node IP rather than a pod CIDR. Standard NetworkPolicy cannot express "from
+# host entity", so we allow all sources on the Envoy proxy's HTTP listen port. Port
+# 10080 is only reachable inside the cluster, limiting the exposure.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-xds-egress-to-envoy-ingress
+  name: allow-proxy-http-ingress
   namespace: envoy-gateway-system
 spec:
-  podSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: proxy
+      app.kubernetes.io/managed-by: envoy-gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 10080
+---
+# Envoy proxy pods (in envoy-gateway-system) route HTTP traffic to backend services.
+# Ports are pod ports: Cilium's socket-level DNAT translates Service port 80 → pod
+# port 3000 before egress NetworkPolicy is evaluated.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-proxy-egress-to-backends
+  namespace: envoy-gateway-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: proxy
+      app.kubernetes.io/managed-by: envoy-gateway
   policyTypes:
     - Egress
   egress:
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: envoy-ingress
+              kubernetes.io/metadata.name: observability
       ports:
-        - port: 18000
+        - port: 3000
+        - port: 9090
 ---
-# ── envoy-ingress (data-plane Envoy proxy pods) ───────────────────────────────
+# ── envoy-ingress (nginx nodeport-proxy DaemonSet only) ──────────────────────
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -209,41 +235,3 @@ spec:
     - ports:
         - port: 8080
         - port: 8443
----
-# Envoy proxy receives xDS configuration from the controller.
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-xds-ingress-from-controller
-  namespace: envoy-ingress
-spec:
-  podSelector: {}
-  policyTypes:
-    - Ingress
-  ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: envoy-gateway-system
-      ports:
-        - port: 18000
----
-# Envoy proxies route traffic to backend services in the observability namespace
-# (Grafana :3000, Prometheus :9090).
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-egress-to-observability
-  namespace: envoy-ingress
-spec:
-  podSelector: {}
-  policyTypes:
-    - Egress
-  egress:
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: observability
-      ports:
-        - port: 3000
-        - port: 9090


### PR DESCRIPTION
## Summary

- **Root cause 1 (NetworkPolicy):** The data-plane Envoy proxy pod runs in `envoy-gateway-system` (not `envoy-ingress` as assumed in PR #24). The `default-deny` in `envoy-gateway-system` blocked two required flows: inbound HTTP from the nginx nodeport-proxy, and outbound egress to the `observability` namespace. Both missing policies are added; three dead policies targeting `envoy-ingress` as the proxy namespace are removed.
- **Root cause 2 (PeerAuthentication):** The `observability` namespace enforces STRICT mTLS cluster-wide. Grafana already had a port-3000 PERMISSIVE exception for Envoy Gateway (which has no Istio sidecar); Prometheus was missing the equivalent on port 9090, causing its Istio sidecar to RST every plain-HTTP connection from Envoy Gateway with a 503.

## Changes

**`infrastructure/controllers/envoy-gateway.yaml`**
- Add `allow-proxy-http-ingress` — allows ingress to proxy pods on port 10080 from any source (hostNetwork pods are seen as node IP; standard NetworkPolicy cannot express "from host entity")
- Add `allow-proxy-egress-to-backends` — allows proxy pods to egress to `observability` on ports 3000 and 9090
- Remove `allow-xds-egress-to-envoy-ingress` (dead — XDS is intra-namespace)
- Remove `allow-xds-ingress-from-controller` from `envoy-ingress` (dead)
- Remove `allow-egress-to-observability` from `envoy-ingress` (dead — proxy is in `envoy-gateway-system`)
- Update comments to correctly describe where proxy pods run

**`apps/base/istio/peerauthentication.yaml`**
- Add `prometheus-port-9090` PeerAuthentication with PERMISSIVE mode on port 9090

## Test plan

- [x] `curl -H "Host: grafana.local" http://localhost:8080/` → 302 ✓
- [x] `curl -H "Host: prometheus.local" http://localhost:8080/` → 302 ✓
- [ ] Verify Flux reconciles cleanly after merge (`flux get all -A`)
- [ ] Confirm Grafana dashboards load in browser at `http://grafana.local:8080`
- [ ] Confirm Prometheus targets page loads at `http://prometheus.local:8080`