### PR TITLE
fix(pqc-watch): rename to Post Quantum Computing, fix YAML block scalar

### DIFF
--- a/.github/workflows/pqc-watch.yaml
+++ b/.github/workflows/pqc-watch.yaml
@@ -1,4 +1,4 @@
-name: PQC Readiness Monitor
+name: Post Quantum Computing
 
 on:
   schedule:
@@ -41,22 +41,25 @@ jobs:
           ROWS+=$(check_tool "Envoy Gateway" "envoyproxy/gateway")$'\n'
           ROWS+=$(check_tool "Cilium"        "cilium/cilium")$'\n'
 
+          # Fires if ANY single tool ships PQC support — does not require all 5.
           DETECTED=$(echo "$ROWS" | grep -c "✅" || true)
 
-          BODY="## 🔐 PQC Readiness Monitor
-
-**Last checked:** $(date -u '+%Y-%m-%d %H:%M UTC')
-
-See \`docs/post-quantum-readiness.md\` for the full analysis — what each tool needs to change and why.
-
-| Tool | Latest Release | PQC Status |
-|---|---|---|
-$ROWS
----
-
-**Watching for:** ML-KEM (FIPS 203) · ML-DSA (FIPS 204) · SLH-DSA (FIPS 205) · post-quantum · Kyber · Dilithium · Sphincs
-
-**Schedule:** Sundays 06:00 UTC · Manual trigger: Actions → PQC Readiness Monitor → Run workflow"
+          LAST_CHECKED=$(date -u '+%Y-%m-%d %H:%M UTC')
+          BODY=$(printf '%s\n' \
+            "## 🔐 PQC Readiness Monitor" \
+            "" \
+            "**Last checked:** ${LAST_CHECKED}" \
+            "" \
+            "See \`docs/post-quantum-readiness.md\` for the full analysis — what each tool needs to change and why." \
+            "" \
+            "| Tool | Latest Release | PQC Status |" \
+            "|---|---|---|" \
+            "${ROWS}" \
+            "---" \
+            "" \
+            "**Watching for:** ML-KEM (FIPS 203) · ML-DSA (FIPS 204) · SLH-DSA (FIPS 205) · post-quantum · Kyber · Dilithium · Sphincs" \
+            "" \
+            "**Schedule:** Sundays 06:00 UTC · Manual trigger: Actions → Post Quantum Computing → Run workflow")
 
           TITLE="🔐 PQC Readiness Monitor"
           if [ "$DETECTED" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- Renames the workflow from `PQC Readiness Monitor` to `Post Quantum Computing` — this is what appears in the GitHub Actions sidebar
- Fixes the root cause of 6 consecutive "workflow file issue" failures: the original `BODY="..."` multiline double-quoted string had content at column 0, which broke out of the YAML block scalar and caused GitHub's YAML parser to reject the file before starting any runner
- Replaces the multiline string with `printf '%s\n'` — all bash content stays properly indented within the YAML block scalar
- Adds a comment making explicit that `DETECTED -gt 0` fires on ANY single tool (not all 5)

## Expected outcome after merge

1. GitHub Actions sidebar shows **Post Quantum Computing**
2. The workflow page shows a **Run workflow** dropdown button (dispatch was hidden because the workflow was invalid)
3. Manual trigger completes successfully and creates/updates the `🔐 PQC Readiness Monitor` issue

## Test plan

- [ ] Merge PR
- [ ] Navigate to Actions → Post Quantum Computing
- [ ] Confirm sidebar name and "Run workflow" button are present
- [ ] Click Run workflow — confirm a new run appears with `workflow_dispatch` event and succeeds