### PR TITLE
fix(trivy): limit concurrent scan jobs to 2 to prevent cache lock contention

### DIFF
--- a/infrastructure/controllers/trivy.yaml
+++ b/infrastructure/controllers/trivy.yaml
@@ -82,6 +82,11 @@ spec:
       # match KinD worker nodes, leaving a pod permanently Pending.
       infraAssessmentScannerEnabled: false
 
+      # Limit parallel scan Jobs to 2 — KinD runs on a single machine and
+      # concurrent Jobs fight over the Trivy DB cache, causing lock timeout
+      # failures and wasted retries.
+      concurrentScanJobsLimit: 2
+
     # Security context for the operator container.
     # Kyverno enforce policy (disallow-privilege-escalation) applies.
     securityContext:


### PR DESCRIPTION
## Problem

Trivy Operator scan Jobs were failing repeatedly with:

```
Failed to acquire cache or database lock
FATAL: unable to initialize cache: cache may be in use by another process: timeout
```

Multiple scan Jobs starting in parallel on the same KinD node fight over the shared Trivy vulnerability DB cache. The jobs retry and eventually succeed (51 VulnerabilityReports and 186 ConfigAuditReports are healthy), but the lock collisions produce ~20+ error log entries per scan cycle and waste CPU/memory on retries.

## Fix

Set `operator.concurrentScanJobsLimit: 2` in the Trivy Operator Helm values. This serializes scan job execution enough that cache lock contention disappears, while still allowing two jobs to overlap (which is safe — they only collide when all start simultaneously).

## Not addressed (no action needed)

- `--slow` deprecation warning — cosmetic, operator passes this flag internally, jobs still complete
- `Deployment "envoy-gateway" not found` reconciler error — stale ReplicaSet reference, self-clears on GC
- `configauditreports already exists` — benign create race, self-resolves on retry
- `Unable to parse digest for openebs/provisioner-localpv` — Trivy can't determine image digest for this image; it's skipped, not an operator bug

## Test plan

- [ ] Merge PR and wait for Flux to reconcile trivy-system HelmRelease
- [ ] Watch `kubectl logs -n trivy-system -l app.kubernetes.io/name=trivy-operator -f`
- [ ] Confirm no more `Failed to acquire cache or database lock` errors in subsequent scan cycles