### PR TITLE
fix(trivy): correct Helm value key to scanJobsConcurrentLimit

### DIFF
--- a/infrastructure/controllers/trivy.yaml
+++ b/infrastructure/controllers/trivy.yaml
@@ -85,7 +85,7 @@ spec:
       # Limit parallel scan Jobs to 2 — KinD runs on a single machine and
       # concurrent Jobs fight over the Trivy DB cache, causing lock timeout
       # failures and wasted retries.
-      concurrentScanJobsLimit: 2
+      scanJobsConcurrentLimit: 2
 
     # Security context for the operator container.
     # Kyverno enforce policy (disallow-privilege-escalation) applies.


### PR DESCRIPTION
## Problem

PR #42 added `operator.concurrentScanJobsLimit: 2` to limit concurrent scan jobs and prevent DB cache lock contention on startup. It had no effect — the `trivy-operator-config` ConfigMap continued to show `OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: "10"`.

Root cause: the Trivy operator Helm chart (0.33.x) exposes **two similarly named keys**:

| Key | Effect |
|-----|--------|
| `operator.concurrentScanJobsLimit` | Silently accepted, does nothing (stale/unused key) |
| `operator.scanJobsConcurrentLimit` | Correct key → sets `OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT` in ConfigMap |

Helm accepted the wrong key without error, so the misconfiguration was invisible.

## Fix

One-line rename: `concurrentScanJobsLimit` → `scanJobsConcurrentLimit`.

## Verification

After merge and Flux reconcile:
```bash
kubectl get cm trivy-operator-config -n trivy-system \
  -o jsonpath='{.data.OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT}'
# Expected output: 2
```

The startup burst of ~16 `cache may be in use by another process` errors that appear every time the operator pod restarts should drop to zero or near-zero once the limit is active.