### PR TITLE
fix(trivy): enable built-in Trivy server to eliminate cache lock contention

### DIFF
--- a/infrastructure/controllers/trivy.yaml
+++ b/infrastructure/controllers/trivy.yaml
@@ -63,6 +63,18 @@ spec:
       ignoreUnfixed: true
 
       # Resources for the scanner container inside each ephemeral scan Job pod.
+      # In ClientServer mode these containers query the server rather than
+      # initializing a local DB, so memory demand is lower — 128Mi is enough.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+
+    trivyServer:
+      # Resources for the built-in Trivy DB server pod.
       resources:
         requests:
           cpu: 100m
@@ -82,9 +94,14 @@ spec:
       # match KinD worker nodes, leaving a pod permanently Pending.
       infraAssessmentScannerEnabled: false
 
-      # Limit parallel scan Jobs to 2 — KinD runs on a single machine and
-      # concurrent Jobs fight over the Trivy DB cache, causing lock timeout
-      # failures and wasted retries.
+      # Spin up a shared Trivy DB server pod. Scan job containers connect to
+      # it as lightweight clients instead of each initializing their own local
+      # DB copy. Eliminates cache lock contention between containers in the
+      # same scan Job pod (the root cause of the startup burst errors).
+      builtInTrivyServer: true
+
+      # Limit parallel scan Jobs to 2 — still useful for resource management
+      # even in ClientServer mode.
       scanJobsConcurrentLimit: 2
 
     # Security context for the operator container.


### PR DESCRIPTION
## Problem

`scanJobsConcurrentLimit: 2` (PR #43) is working — jobs run in sequential batches of 2.
However, cache lock contention still occurs. Log analysis shows errors like:

```
6 errors in 1 second from scan-c84ff9879
```

All errors originate within a **single Job pod**, not between Jobs. Each scan Job creates
one container per image to scan; all containers start simultaneously and share the same
`/tmp/trivy/.cache` emptyDir volume. When multiple trivy processes race to initialize the
vulnerability DB from the same path, they deadlock on the filesystem lock.

`scanJobsConcurrentLimit` controls Job-level parallelism but has no effect on the
within-Job container parallelism that is causing these errors.

## Fix

Enable `operator.builtInTrivyServer: true`.

This causes the operator to deploy a dedicated `trivy-server` pod in `trivy-system` that
downloads and maintains the Trivy vulnerability DB. Scan job containers switch to client
mode: they query the server over HTTP instead of initializing a local DB copy. There is
no per-container DB initialization, so the filesystem lock is never contended.

Side effect: scan job container memory can be reduced from 256Mi to 128Mi since they no
longer need to hold the DB in memory locally.

## What changes in the cluster

- New `trivy-server` Deployment in `trivy-system` (1 pod, ~256Mi memory for the DB)
- `OPERATOR_BUILT_IN_TRIVY_SERVER: "true"` in the operator ConfigMap
- `trivy.mode` in the trivy config ConfigMap changes to `ClientServer`
- Scan job container memory limit reduced from 512Mi to 256Mi

The existing `allow-intra-namespace` NetworkPolicy already permits scan pods to reach the
server pod within `trivy-system`, so no NetworkPolicy changes are needed.

## Verification

After merge and Flux reconcile:
```bash
# Confirm server pod is running
kubectl get pods -n trivy-system

# Confirm mode is ClientServer
kubectl get cm trivy-operator-trivy-config -n trivy-system \
  -o jsonpath='{.data.trivy\.mode}'
# Expected: ClientServer

# Watch the next scan cycle — no cache lock errors should appear
kubectl logs -n trivy-system -l app.kubernetes.io/name=trivy-operator -f \
  | grep -i "cache\|lock\|fatal"
```