### PR TITLE
fix(trivy): move server config under trivy.server, add security context for Kyverno

### DIFF
--- a/infrastructure/controllers/trivy.yaml
+++ b/infrastructure/controllers/trivy.yaml
@@ -73,15 +73,27 @@ spec:
           cpu: 500m
           memory: 256Mi
 
-    trivyServer:
-      # Resources for the built-in Trivy DB server pod.
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          cpu: 500m
-          memory: 512Mi
+      server:
+        # Resources for the built-in Trivy DB server StatefulSet pod.
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+        # Kyverno enforce policies (disallow-privilege-escalation, require-resource-limits)
+        # apply to all pods in trivy-system, including the trivy-server StatefulSet.
+        podSecurityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop: [ALL]
 
     operator:
       # Bind metrics on :8080 — scraped via additionalScrapeConfigs in


### PR DESCRIPTION
## Problem

Two issues prevented the built-in Trivy server from deploying:

1. **Wrong Helm key** — `trivyServer:` was a top-level key that the chart doesn't recognise. The correct path is `trivy.server:` (nested under the `trivy:` block).

2. **Missing security context on the server StatefulSet** — Kyverno's `disallow-privilege-escalation` policy blocked the `trivy-server` StatefulSet with:
   ```
   admission webhook "validate.kyverno.svc-fail" denied the request:
   resource StatefulSet/trivy-system/trivy-server was blocked due to the following policies
   disallow-privilege-escalation: Unknown key "allowPrivilegeEscalation" in path
   ```
   The server container had no `securityContext` at all, so Kyverno couldn't evaluate the policy and denied it.

## Fix

- Move server resources from `trivyServer.resources` → `trivy.server.resources`
- Add `trivy.server.podSecurityContext` and `trivy.server.securityContext` matching the same Kyverno-compliant pattern already used by the operator container and scan job pods

## Verification

After merge and Flux reconcile:
```bash
# trivy-server-0 pod should be Running alongside the operator
kubectl get pods -n trivy-system

# Mode should be ClientServer
kubectl get cm trivy-operator-trivy-config -n trivy-system \
  -o jsonpath='{.data.trivy\.mode}'

# No cache lock errors on next scan cycle
kubectl logs -n trivy-system -l app.kubernetes.io/name=trivy-operator \
  | grep -c "cache lock"
# Expected: 0
```