### PR TITLE
fix(trivy): increase scan container memory limit to 512Mi for large images

### DIFF
--- a/infrastructure/controllers/trivy.yaml
+++ b/infrastructure/controllers/trivy.yaml
@@ -63,15 +63,16 @@ spec:
       ignoreUnfixed: true
 
       # Resources for the scanner container inside each ephemeral scan Job pod.
-      # In ClientServer mode these containers query the server rather than
-      # initializing a local DB, so memory demand is lower — 128Mi is enough.
+      # ClientServer mode offloads DB lookups to the server, but each container
+      # still pulls the image and extracts layers locally. Large images (Cilium,
+      # Envoy) OOMKill at 256Mi — 512Mi accommodates the largest images in the stack.
       resources:
         requests:
           cpu: 100m
-          memory: 128Mi
+          memory: 256Mi
         limits:
           cpu: 500m
-          memory: 256Mi
+          memory: 512Mi
 
       server:
         # Resources for the built-in Trivy DB server StatefulSet pod.


### PR DESCRIPTION
## Problem

After switching to ClientServer mode, scan container memory was reduced from 512Mi to 256Mi on the assumption that offloading DB lookups to the server would reduce per-container memory needs. That assumption was wrong.

In ClientServer mode, scan containers **still pull the full image and extract layers locally** — they send the extracted package list to the server, not the raw image. Large images in this cluster require more than 256Mi:

| Container | Job | Result |
|---|---|---|
| cilium-agent | scan-c84ff9879 | OOMKilled |
| apply-sysctl-overwrites | scan-c84ff9879 | OOMKilled |
| clean-cilium-state | scan-c84ff9879 | OOMKilled |
| config | scan-c84ff9879 | OOMKilled |
| install-cni-binaries | scan-c84ff9879 | OOMKilled |
| mount-bpf-fs | scan-c84ff9879 | OOMKilled |
| mount-cgroup | scan-c84ff9879 | OOMKilled |
| prometheus | scan-757795c96c | FATAL: /tmp/trivy-11 no such file or directory |
| envoy | scan-6d64bd65f4 | FATAL: unexpected EOF on usr/local/bin/envoy |

The FATAL errors for prometheus and envoy are secondary effects of memory exhaustion — temp dir creation fails and binary buffering hits EOF when the container runs out of memory.

## Fix

Restore scan container memory: requests `128Mi → 256Mi`, limit `256Mi → 512Mi`.

## Verification

After merge and Flux reconcile, watch the next scan cycle:
```bash
kubectl logs -n trivy-system -l app.kubernetes.io/name=trivy-operator -f \
  | grep -iE "oom|fatal|killed"
# Expected: no output
```