### PR TITLE
chore: update repo URL references for rename to homelab-gitops-k8s-2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# flux-cluster
+# homelab-gitops-k8s-2026
 
 FluxCD GitOps cluster for KinD — multi-node, Cilium CNI with kube-proxy replacement, Hubble observability, Istio service mesh (mTLS), Envoy Gateway for HTTP ingress.
 
@@ -26,7 +26,7 @@ FluxCD GitOps cluster for KinD — multi-node, Cilium CNI with kube-proxy replac
 ## Repository Structure
 
 ```text
-flux-cluster/
+homelab-gitops-k8s-2026/
 ├── .github/workflows/
 │   ├── renovate.yaml              # Scheduled self-hosted Renovate run (daily + workflow_dispatch)
 │   └── validate.yaml              # CI: Gitleaks secret scan + kustomize build + Kyverno tests + Kubescape scan on every PR

--- a/apps/base/notifications/provider.yaml
+++ b/apps/base/notifications/provider.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: flux-system
 spec:
   type: github
-  address: https://github.com/DevOpsMaestro/flux-cluster
+  address: https://github.com/DevOpsMaestro/homelab-gitops-k8s-2026
   secretRef:
     name: github-token

--- a/clusters/kind/flux-system/gotk-sync.yaml
+++ b/clusters/kind/flux-system/gotk-sync.yaml
@@ -11,7 +11,7 @@ spec:
     branch: main
   secretRef:
     name: flux-system
-  url: https://github.com/DevOpsMaestro/flux-cluster.git
+  url: https://github.com/DevOpsMaestro/homelab-gitops-k8s-2026.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -1123,7 +1123,7 @@ kubectl logs -n flux-system deploy/notification-controller | grep -i "error"
 
 ```bash
 # After a reconcile, check the commit SHA for pending/success/failure statuses
-gh api repos/DevOpsMaestro/flux-cluster/commits/$(git rev-parse HEAD)/statuses \
+gh api repos/DevOpsMaestro/homelab-gitops-k8s-2026/commits/$(git rev-parse HEAD)/statuses \
   | jq '.[0:3] | .[] | {state: .state, context: .context, updated_at: .updated_at}'
 ```
 


### PR DESCRIPTION
## What

Updates all hardcoded repository URL references following the GitHub rename from `flux-cluster` → `homelab-gitops-k8s-2026`.

## Files changed

| File | Change |
|---|---|
| `clusters/kind/flux-system/gotk-sync.yaml` | Flux GitRepository source URL — **critical**, Flux reads this to sync |
| `apps/base/notifications/provider.yaml` | Flux notification provider address |
| `docs/troubleshooting-guide.md` | `gh api` example command |
| `README.md` | H1 title and directory tree label |

## What was NOT changed

- `CLUSTER_NAME=flux-kind` in `versions.env` — the KinD cluster name is independent of the repo name; changing it requires tearing down the cluster
- `infrastructure/controllers/cilium.yaml` — `k8sServiceHost: "flux-kind-control-plane"` stays (tied to KinD cluster name)
- `infrastructure/controllers/kubescape.yaml` — `clusterName: flux-kind` stays
- Grafana dashboard UID / PrometheusRule names — cosmetic internal identifiers, no functional impact

## After merging

Force Flux to pick up the new URL immediately (GitHub's redirect keeps sync alive in the meantime):
```bash
flux reconcile source git flux-system -n flux-system
```