### PR TITLE
docs: audit and update all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ FluxCD GitOps cluster for KinD — multi-node, Cilium CNI with kube-proxy replac
 
 | Document | Description |
 |---|---|
-| [Key Concepts](docs/concepts.md) | What each technology is and why it exists — recommended starting point for operators new to Kubernetes |
+| [Key Concepts](docs/key_concepts.md) | What each technology is and why it exists — recommended starting point for operators new to Kubernetes |
 | [Troubleshooting Guide](docs/troubleshooting-guide.md) | Per-technology verification commands and common issue resolutions |
 | [SOPS + Age Secrets](docs/sops-age-secrets.md) | Secrets encryption setup, day-to-day workflow, and recovery procedure |
 | [BOINC](docs/boinc.md) | BOINC compute DaemonSet — status commands, credential updates, and troubleshooting |
 | [Renovate](docs/renovate.md) | Dependency automation — configuration, tiered strategy, and rollback procedure |
+| [Trivy Operator](docs/trivy.md) | Image vulnerability scanning — listing reports, filtering CVEs, Prometheus metrics, and force re-scan |
+| [Post-Quantum Cryptography Readiness](docs/post-quantum-readiness.md) | Cryptographic inventory, NIST PQC standards mapping, and upgrade roadmap |
 | [Kubescape Accepted Risks](docs/kubescape-security.md) | Security findings reviewed and accepted as intentional design decisions |
 | [Istio Basic Reference](docs/ISTIO_basic_notes.md) | Day-to-day Istio administration commands |
 | [Istio Advanced Reference](docs/ISTIO_advanced_notes.md) | mTLS enforcement, authorization policy, tracing configuration |
@@ -178,28 +180,28 @@ flux-system (GitRepository)
 
 | Component | Chart / Source | Version | Namespace | Notes |
 |---|---|---|---|---|
-| Cilium CNI | cilium/cilium | 1.19.x | kube-system | |
-| Hubble Relay | (bundled with Cilium) | 1.19.x | kube-system | |
+| Cilium CNI | cilium/cilium | 1.19.4 | kube-system | |
+| Hubble Relay | (bundled with Cilium) | 1.19.4 | kube-system | |
 | Hubble UI | (bundled with Cilium) | 0.13.1 | kube-system | Disabled by default; enable via `hubble.ui.enabled: true` in `cilium.yaml` |
-| cert-manager | cert-manager/cert-manager | v1.20.x | cert-manager | |
-| OpenEBS localpv | openebs/openebs | 4.x | openebs | |
-| istio-base | istio/base | 1.30.x | istio-system | |
-| istiod | istio/istiod | 1.30.x | istio-system | |
+| cert-manager | cert-manager/cert-manager | v1.20.2 | cert-manager | |
+| OpenEBS localpv | openebs/openebs | 4.5.0 | openebs | |
+| istio-base | istio/base | 1.30.1 | istio-system | |
+| istiod | istio/istiod | 1.30.1 | istio-system | |
 | Gateway API CRDs | kubernetes-sigs/gateway-api | v1.2.1 | (cluster-scoped) | |
-| Envoy Gateway | envoy-gateway/gateway | 1.4.x | envoy-gateway-system | |
-| Envoy Gateway data-plane | gatewayClassName: eg | 1.4.x | envoy-ingress | |
-| Metrics Server | metrics-server/metrics-server | 3.x | metrics-server | Powers `kubectl top` and HPA; `--kubelet-insecure-tls` required for KinD |
-| kube-prometheus-stack | prometheus-community/kube-prometheus-stack | 86.x | observability | |
-| Grafana | grafana/grafana | 10.x (app 12.x) | observability | |
-| Loki | grafana/loki | 7.x | observability | |
-| Promtail | grafana/promtail | 6.x | observability | |
-| Grafana Tempo | grafana/tempo | 1.x | observability | Single-binary mode; trace backend for the OTel pipeline |
-| OpenTelemetry Collector | open-telemetry/opentelemetry-collector | 0.x | observability | Contrib distribution; OTLP ingress → Tempo export; Istio sidecar disabled |
-| Tetragon | cilium/tetragon | 1.7.x | tetragon | |
-| Kyverno | kyverno/kyverno | 3.x | kyverno | |
-| Kubescape | kubescape/kubescape-operator | 1.40.x | kubescape | NSA + MITRE continuous scan; vulnerability scan disabled for KinD |
-| Falco + Falcosidekick | falcosecurity/falco | 9.x | falco | |
-| Trivy Operator | aquasecurity/trivy-operator | 0.x | trivy-system | Image CVE scanning — VulnerabilityReport CRDs + Prometheus metrics; `ignoreUnfixed: true` |
+| Envoy Gateway | envoy-gateway/gateway | 1.4.6 | envoy-gateway-system | |
+| Envoy Gateway data-plane | gatewayClassName: eg | 1.4.6 | envoy-ingress | |
+| Metrics Server | metrics-server/metrics-server | 3.13.1 | metrics-server | Powers `kubectl top` and HPA; `--kubelet-insecure-tls` required for KinD |
+| kube-prometheus-stack | prometheus-community/kube-prometheus-stack | 86.2.2 | observability | |
+| Grafana | grafana/grafana | 10.5.15 | observability | |
+| Loki | grafana/loki | 7.0.0 | observability | |
+| Promtail | grafana/promtail | 6.17.1 | observability | |
+| Grafana Tempo | grafana/tempo | 1.24.4 | observability | Single-binary mode; trace backend for the OTel pipeline |
+| OpenTelemetry Collector | open-telemetry/opentelemetry-collector | 0.158.1 | observability | Contrib distribution; OTLP ingress → Tempo export; Istio sidecar disabled |
+| Tetragon | cilium/tetragon | 1.7.0 | tetragon | |
+| Kyverno | kyverno/kyverno | 3.8.1 | kyverno | |
+| Kubescape | kubescape/kubescape-operator | 1.40.2 | kubescape | NSA + MITRE continuous scan; vulnerability scan disabled for KinD |
+| Falco + Falcosidekick | falcosecurity/falco | 9.1.0 | falco | |
+| Trivy Operator | aquasecurity/trivy-operator | 0.33.1 | trivy-system | Image CVE scanning — VulnerabilityReport CRDs + Prometheus metrics; `ignoreUnfixed: true` |
 | demo (httpbin) | kennethreitz/httpbin | @sha256 digest pin | demo | No versioned tags published; pinned by digest |
 | BOINC | boinc/client | arm64v8 | boinc | Voluntary compute — Rosetta@Home + Einstein@Home; capped at 1 CPU core for thermal management |
 | Renovate | renovatebot/github-action | (GitHub Actions workflow) | — | Automated dependency PRs for Helm charts, images, GitHub Actions, and CI tool pins |
@@ -225,20 +227,20 @@ The versions below were validated together. When upgrading a component, verify c
 | Component | Validated Version | Constrained By |
 |---|---|---|
 | Kubernetes (KinD node) | v1.36.1 | `K8S_VER` in `versions.env` |
-| Cilium | 1.19.x | `cilium.yaml` chart constraint + `versions.env` |
-| Istio | 1.30.x | `istio.yaml` chart constraint + `versions.env` |
-| Envoy Gateway | 1.4.x (v1.4.6) | `envoy-gateway.yaml` + `versions.env` |
+| Cilium | 1.19.4 | `cilium.yaml` chart constraint + `versions.env` |
+| Istio | 1.30.1 | `istio.yaml` chart constraint + `versions.env` |
+| Envoy Gateway | 1.4.6 | `envoy-gateway.yaml` + `versions.env` |
 | Gateway API CRDs | v1.2.1 | Hardcoded in `setup-fluxcd-gitops-kind-multinode.sh` step 4 |
-| kube-prometheus-stack | 86.x | `prometheus/helmrelease.yaml` |
-| Loki | 7.x | `loki/helmrelease.yaml` |
-| Grafana | 10.x (app 12.x) | `grafana/helmrelease.yaml` |
-| Grafana Tempo | 1.x | `tempo/helmrelease.yaml` |
-| OpenTelemetry Collector | 0.x | `opentelemetry/helmrelease.yaml` |
-| Kyverno | 3.x | `kyverno.yaml` |
-| Kubescape | 1.40.x | `kubescape.yaml` |
-| Falco | 9.x | `falco.yaml` |
-| Tetragon | 1.7.x | `tetragon.yaml` |
-| Trivy Operator | 0.x | `trivy.yaml` |
+| kube-prometheus-stack | 86.2.2 | `prometheus/helmrelease.yaml` |
+| Loki | 7.0.0 | `loki/helmrelease.yaml` |
+| Grafana | 10.5.15 | `grafana/helmrelease.yaml` |
+| Grafana Tempo | 1.24.4 | `tempo/helmrelease.yaml` |
+| OpenTelemetry Collector | 0.158.1 | `opentelemetry/helmrelease.yaml` |
+| Kyverno | 3.8.1 | `kyverno.yaml` |
+| Kubescape | 1.40.2 | `kubescape.yaml` |
+| Falco | 9.1.0 | `falco.yaml` |
+| Tetragon | 1.7.0 | `tetragon.yaml` |
+| Trivy Operator | 0.33.1 | `trivy.yaml` |
 
 All version pins shared between the Makefile and setup script are sourced from `versions.env` at the repository root — bumping them there updates both consumers.
 

--- a/docs/key_concepts.md
+++ b/docs/key_concepts.md
@@ -267,6 +267,67 @@ kubectl get vulnerabilityreports -A
 
 ---
 
+## Observability Stack
+
+**Observability** means being able to answer "what is the cluster doing right now?" without modifying any application code. This cluster uses six tools that each capture a different type of signal and feed them into a single dashboard system.
+
+| Tool | What It Captures | Chart Version |
+|------|-----------------|---------------|
+| **Prometheus** (`kube-prometheus-stack`) | Metrics — numbers over time (CPU %, request rate, error count) | 86.2.2 |
+| **Grafana** | Dashboards — visual graphs and tables built from Prometheus and Loki data | 10.5.15 |
+| **Loki** | Logs — the text output of every container in the cluster | 7.0.0 |
+| **Promtail** | Log collector — a DaemonSet that reads log files on each node and ships them to Loki | 6.17.1 |
+| **Grafana Tempo** | Distributed traces — records the full path a request takes through multiple services | 1.24.4 |
+| **OpenTelemetry Collector** | Trace pipeline — receives OTLP trace spans from Istio Envoy sidecars and forwards them to Tempo | 0.158.1 |
+
+**How they connect:**
+
+```
+Every pod log file
+  └─► Promtail (DaemonSet, runs on every node)
+        └─► Loki (log storage, SingleBinary mode)
+              └─► Grafana (dashboards query Loki for log panels)
+
+Every cluster component
+  └─► Prometheus (scrapes /metrics endpoints every 30 s)
+        └─► Grafana (dashboards query Prometheus for metric panels)
+
+Istio Envoy sidecar (every injected pod)
+  └─► OTel Collector (receives OTLP spans on gRPC port 4317)
+        └─► Tempo (trace storage)
+              └─► Grafana (trace explorer + dashboard links)
+```
+
+Grafana comes pre-loaded with 16 dashboards covering Cilium, Hubble, Istio, Flux, Falco, Tetragon, Kubescape, cert-manager, node resources, and the OpenTelemetry Collector itself.
+
+**Why `additionalScrapeConfigs` instead of `ServiceMonitor` CRDs?** Infrastructure tools like Cilium, Falco, and Trivy Operator are deployed in the `infrastructure-controllers` layer, which runs before Prometheus is installed. The `ServiceMonitor` CRD (provided by `kube-prometheus-stack`) does not exist at that point, so configuring scraping through it would fail. Instead, Prometheus is given static scrape configs that use Kubernetes pod-based service discovery — no CRD dependency required.
+
+---
+
+## Post-Quantum Cryptography
+
+**Post-Quantum Cryptography (PQC)** refers to encryption algorithms designed to remain secure even against a cryptographically relevant quantum computer. Conventional public-key cryptography — such as RSA and Elliptic Curve Cryptography (ECC) — can be broken by Shor's algorithm running on a sufficiently powerful quantum computer. NIST finalized three replacement standards in August 2024:
+
+- **ML-KEM (FIPS 203)** — replaces X25519/ECDH key exchange (used in SOPS + Age)
+- **ML-DSA (FIPS 204)** — replaces ECDSA digital signatures (used in Istio workload certificates)
+- **SLH-DSA (FIPS 205)** — a hash-based backup signature scheme
+
+**What this cluster uses today:**
+
+| Component | Algorithm at Risk | Status |
+|-----------|------------------|--------|
+| SOPS + Age | X25519 key encapsulation | No PQC support yet |
+| Istio mTLS workload certs | ECDSA P-256 | No PQC support yet |
+| Envoy Gateway | None (HTTP only, no TLS) | N/A |
+
+**Important note:** Symmetric encryption (AES-256, ChaCha20-Poly1305) is already quantum-safe — Grover's algorithm only halves effective key strength, leaving 256-bit keys with approximately 128 bits of security, which is considered adequate. The threat is confined to asymmetric key exchange and digital signatures.
+
+No component in this cluster can be switched to a NIST PQC algorithm today without breaking things. Every relevant tool (Age, Istio, cert-manager, Envoy) lacks stable PQC support. The `Post Quantum Computing` GitHub Actions workflow (`.github/workflows/pqc-watch.yaml`) runs weekly and creates a dashboard issue in this repository when any of the five tracked tools ships PQC support.
+
+See [docs/post-quantum-readiness.md](post-quantum-readiness.md) for the complete per-component inventory, algorithm mapping, and upgrade roadmap.
+
+---
+
 ## Demo Namespace — httpbin and load-generator
 
 The `demo` namespace contains two workloads that exist purely to generate traffic through the Istio mesh:

--- a/docs/post-quantum-readiness.md
+++ b/docs/post-quantum-readiness.md
@@ -78,7 +78,7 @@ sidecar-injected pod. Certificates rotate every 24 hours by default.
 
 ### 3. cert-manager (Installed, No Active Issuers)
 
-**Config:** `infrastructure/controllers/cert-manager.yaml` — version 1.20.x
+**Config:** `infrastructure/controllers/cert-manager.yaml` — version v1.20.2
 
 cert-manager is installed as an Istio dependency. No `Certificate`, `Issuer`, or
 `ClusterIssuer` CRDs are deployed — it is not currently issuing any certificates.
@@ -142,6 +142,12 @@ its own built-in certificate generator (RSA or ECDSA, version-dependent).
 | Envoy Gateway | None (HTTP only) | ML-KEM (FIPS 203) when HTTPS added | N/A |
 | OTel → Tempo gRPC | None (TLS disabled) | N/A | N/A |
 | Cilium Hubble PKI | ECDSA / RSA (default) | ML-DSA (FIPS 204) | ❌ No |
+
+---
+
+## Automated Monitoring
+
+The `Post Quantum Computing` GitHub Actions workflow (`.github/workflows/pqc-watch.yaml`) runs on a weekly schedule. It checks whether Age, Istio, cert-manager, Envoy, and Cilium have shipped PQC support, and creates or updates a GitHub issue in this repository summarizing the findings. When the issue shows a tool has added support, return to the relevant section in this document and proceed with the upgrade steps.
 
 ---
 

--- a/images/architecture.svg
+++ b/images/architecture.svg
@@ -12,7 +12,7 @@
   <rect width="1200" height="900" fill="#FAFAFA"/>
 
   <!-- Title -->
-  <text x="600" y="36" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="20" font-weight="700" fill="#0F172A">flux-cluster — Architecture Overview</text>
+  <text x="600" y="36" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="20" font-weight="700" fill="#0F172A">homelab-gitops-k8s-2026 — Architecture Overview</text>
 
   <!-- ══════════════════════════════════════════════════════════
        Band 1 · GitOps Control Plane
@@ -24,9 +24,9 @@
   <rect x="50" y="82" width="210" height="104" rx="8" fill="white" stroke="#1E293B" stroke-width="2"/>
   <text x="155" y="103" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="13" font-weight="700" fill="#1E293B">GitHub</text>
   <line x1="58" y1="110" x2="252" y2="110" stroke="#1E293B" stroke-width="0.75" opacity="0.35"/>
-  <text x="155" y="127" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">DevOpsMaestro/flux-cluster</text>
+  <text x="155" y="127" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">DevOpsMaestro/homelab-gitops-k8s-2026</text>
   <text x="155" y="143" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">branch: main</text>
-  <text x="155" y="159" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">GitRepository poll · 1h interval</text>
+  <text x="155" y="159" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">GitRepository poll · 1m interval</text>
   <text x="155" y="175" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#475569">CI: validate.yaml on every PR</text>
 
   <!-- Arrow GitHub → Flux -->
@@ -246,5 +246,5 @@
     <tspan font-weight="700" fill="#B91C1C">Kubescape</tspan>
     <tspan> — NSA + MITRE continuous compliance scan · configurationScan + continuousScan · posture metrics on :8080 → Prometheus</tspan>
   </text>
-  <text x="600" y="898" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" font-style="italic" fill="#94A3B8">Four-layer defense: prevent (Kyverno) · enforce (Tetragon) · detect &amp; alert (Falco) · audit posture (Kubescape)</text>
+  <text x="600" y="898" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" font-style="italic" fill="#94A3B8">Five-layer defense: prevent (Kyverno) · enforce (Tetragon) · detect &amp; alert (Falco) · audit posture (Kubescape) · scan CVEs (Trivy)</text>
 </svg>

--- a/images/flow.svg
+++ b/images/flow.svg
@@ -18,7 +18,7 @@
   <rect width="900" height="830" fill="#FAFAFA"/>
 
   <!-- Title -->
-  <text x="450" y="34" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="18" font-weight="700" fill="#0F172A">flux-cluster — GitOps Reconciliation Flow</text>
+  <text x="450" y="34" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="18" font-weight="700" fill="#0F172A">homelab-gitops-k8s-2026 — GitOps Reconciliation Flow</text>
 
   <!-- ══════════════════════════════════════════════════════
        TRIGGER SECTION
@@ -35,11 +35,11 @@
   <!-- GitHub box -->
   <rect x="310" y="118" width="280" height="52" rx="8" fill="#1E293B" stroke="#0F172A" stroke-width="1.5"/>
   <text x="450" y="137" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="12" font-weight="700" fill="white">GitHub</text>
-  <text x="450" y="154" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#94A3B8">DevOpsMaestro/flux-cluster · branch: main</text>
+  <text x="450" y="154" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#94A3B8">DevOpsMaestro/homelab-gitops-k8s-2026 · branch: main</text>
 
   <!-- arrow to source-controller -->
   <line x1="450" y1="170" x2="450" y2="192" stroke="#4F46E5" stroke-width="1.5" marker-end="url(#arr-indigo)"/>
-  <text x="462" y="184" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#4F46E5">poll 1h / webhook</text>
+  <text x="462" y="184" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#4F46E5">poll 1m / webhook</text>
 
   <!-- source-controller box -->
   <rect x="290" y="196" width="320" height="52" rx="8" fill="white" stroke="#4F46E5" stroke-width="2"/>

--- a/images/network-topology.svg
+++ b/images/network-topology.svg
@@ -24,7 +24,7 @@
   <rect width="1100" height="780" fill="#F8FAFC"/>
 
   <!-- Title -->
-  <text x="550" y="30" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="18" font-weight="700" fill="#0F172A">flux-cluster — Network Topology</text>
+  <text x="550" y="30" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="18" font-weight="700" fill="#0F172A">homelab-gitops-k8s-2026 — Network Topology</text>
 
   <!-- ══════════════════════════════════════════════════
        macOS HOST


### PR DESCRIPTION
## Summary

- **Rename** `docs/concepts.md` → `docs/key_concepts.md`; update all links to match
- **Expand** `key_concepts.md` with two new sections: Observability Stack (Prometheus, Grafana, Loki, Promtail, Tempo, OTel Collector) and Post-Quantum Cryptography (intro + component table + pointer to readiness doc)
- **README**: add `trivy.md` and `post-quantum-readiness.md` to the Documentation table; update all chart versions from `.x` ranges to exact validated versions (Cilium 1.19.4, Istio 1.30.1, kube-prometheus-stack 86.2.2, etc.)
- **SVG diagrams**: rename `flux-cluster` → `homelab-gitops-k8s-2026` in all three diagram titles; fix factual error — GitRepository poll interval was shown as `1h`, correct value is `1m` (matches `gotk-sync.yaml`); fix repo URL in architecture and flow diagrams; update architecture footnote from four-layer to five-layer security model (Trivy is the fifth layer)
- **`docs/post-quantum-readiness.md`**: cert-manager version `1.20.x` → `v1.20.2`; add Automated Monitoring section referencing the `Post Quantum Computing` GitHub Actions workflow

## Test plan

- [ ] Click all Documentation table links in the rendered README — all must resolve
- [ ] Confirm `docs/concepts.md` returns 404; `docs/key_concepts.md` loads correctly
- [ ] View each SVG in GitHub — titles show `homelab-gitops-k8s-2026`, poll interval shows `1m`
- [ ] `grep -r "docs/concepts.md" .` returns zero results
- [ ] CI `validate` workflow passes