### PR TITLE
fix(bootstrap): update REPO_NAME to homelab-gitops-k8s-2026 after rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Makefile — flux-cluster
+# Makefile — homelab-gitops-k8s-2026
 # Wraps common cluster operations and provides an image pre-pull workflow to
 # speed up repeated cluster rebuilds on macOS with Docker Desktop + KinD.
 #

--- a/scripts/setup-fluxcd-gitops-kind-multinode.sh
+++ b/scripts/setup-fluxcd-gitops-kind-multinode.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${REPO_ROOT}/versions.env"
 
 GITHUB_USER="DevOpsMaestro"
-REPO_NAME="flux-cluster"
+REPO_NAME="homelab-gitops-k8s-2026"
 BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 CLUSTER_PATH="clusters/kind"
 


### PR DESCRIPTION
## Summary

- `REPO_NAME` in `scripts/setup-fluxcd-gitops-kind-multinode.sh` was still set to `flux-cluster` (the pre-rename value).
- Flux bootstrap used that name to generate sync manifests, producing a URL that differed from what was already committed in `gotk-sync.yaml`.
- The resulting diff caused Flux to commit and push — to the old remote URL — which the branch ruleset rejected.
- Stale `flux-cluster` reference in the Makefile header comment is corrected as well.

## Root cause chain

1. `REPO_NAME="flux-cluster"` → Flux generates `url: https://github.com/DevOpsMaestro/flux-cluster.git` in the sync manifest.
2. Committed `gotk-sync.yaml` already contains `url: https://github.com/DevOpsMaestro/homelab-gitops-k8s-2026.git`.
3. Mismatch → Flux commits a new sync manifest and pushes to the old (now redirected) remote.
4. Push to `refs/heads/main` is rejected by the branch ruleset.

## Test plan

- [ ] Merge this PR so `main` has the correct `REPO_NAME`.
- [ ] Run `make bootstrap` on a fresh cluster and confirm step 8 completes without a push (sync manifests match what is already on `main`).