### PR TITLE
fix(kyverno): add missing resource limits for tetragon and envoy-gateway

### DIFF
--- a/apps/base/envoy-gateway/gateway.yaml
+++ b/apps/base/envoy-gateway/gateway.yaml
@@ -51,6 +51,25 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+        # The shutdown-manager sidecar is injected by the controller and has no
+        # dedicated EnvoyProxy field. A strategic-merge patch is the only way to
+        # set its resource limits; without this the sidecar fails the Kyverno
+        # require-resource-limits policy at admission and blocks pod restarts.
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: shutdown-manager
+                      resources:
+                        requests:
+                          cpu: 10m
+                          memory: 32Mi
+                        limits:
+                          cpu: 50m
+                          memory: 64Mi
 ---
 # Gateway CR — Envoy Gateway auto-provisions the Envoy Deployment + Service in this
 # namespace when it sees gatewayClassName: eg. The infrastructure.parametersRef

--- a/infrastructure/controllers/envoy-gateway.yaml
+++ b/infrastructure/controllers/envoy-gateway.yaml
@@ -57,13 +57,16 @@ spec:
     autoscaling:
       enabled: false
     deployment:
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          cpu: 500m
-          memory: 512Mi
+      # Chart key is deployment.envoyGateway.resources (not deployment.resources).
+      # The bare deployment.resources path is silently ignored by the chart.
+      envoyGateway:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
 ---
 # ── envoy-gateway-system (controller) ────────────────────────────────────────
 apiVersion: networking.k8s.io/v1

--- a/infrastructure/controllers/tetragon.yaml
+++ b/infrastructure/controllers/tetragon.yaml
@@ -62,6 +62,18 @@ spec:
         limits:
           cpu: 500m
           memory: 512Mi
+    # export.resources controls the export-stdout sidecar container (chart key is
+    # top-level, separate from tetragon.resources which covers the main agent).
+    # Without this the sidecar has no limits and fails the require-resource-limits
+    # Kyverno policy at admission time whenever the DaemonSet pod restarts.
+    export:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          cpu: 50m
+          memory: 32Mi
     tetragonOperator:
       prometheus:
         enabled: true


### PR DESCRIPTION
## Summary

Closes three gaps where containers violated the `require-resource-limits` Kyverno Enforce policy. Pods only exist in the cluster today because they were admitted during bootstrap before Kyverno was ready (`webhooksFailurePolicy: Ignore`). Any pod restart while Kyverno is running would be blocked at admission.

- **Tetragon `export-stdout` sidecar** — add `export.resources` at the top-level chart key (separate from `tetragon.resources`, which covers only the main agent container).
- **Envoy Gateway controller** — the existing `deployment.resources` key is silently ignored by the gateway-helm chart; the correct path is `deployment.envoyGateway.resources`. This also adds the missing cpu limit (the chart default has no cpu limit).
- **Envoy Gateway `shutdown-manager` sidecar** — this container is injected by the controller and has no dedicated EnvoyProxy CRD field. A `StrategicMerge` patch on `envoyDeployment.patch` is the only supported mechanism.

## Root cause

| Container | Gap |
|---|---|
| `tetragon/export-stdout` | `export.resources` chart key was not set; chart has no default limits for this sidecar |
| `envoy-gateway/envoy-gateway` | `deployment.resources` is a nonexistent chart path; silently ignored, leaving the chart default (no cpu limit) |
| `envoy-gateway-system/shutdown-manager` | No dedicated CRD or chart field; requires deployment patch |

## Test plan

- [ ] Validate CI passes (kustomize build, Kyverno tests, Kubescape).
- [ ] After merge and Flux reconciliation, confirm `kubectl get policyreport -n tetragon` and `kubectl get policyreport -n envoy-gateway-system` show no `require-resource-limits` failures.
- [ ] Confirm `kubectl get pod -n envoy-gateway-system envoy-gateway-... -o jsonpath='{.spec.containers[0].resources}'` shows a cpu limit.