### PR TITLE
fix(kubescape): allow kube-apiserver to reach storage aggregated APIService

### DIFF
--- a/infrastructure/controllers/kubescape.yaml
+++ b/infrastructure/controllers/kubescape.yaml
@@ -148,3 +148,27 @@ spec:
               kubernetes.io/metadata.name: observability
       ports:
         - port: 8080
+---
+# The kube-apiserver reaches the storage aggregated APIService from the node's
+# host network IP. Standard NetworkPolicy cannot select host-network peers by
+# namespace or label, so ipBlock covers the full KinD node subnet (172.18.0.0/16).
+# Without this, default-deny blocks the aggregated API health check and the
+# v1beta1.spdx.softwarecomposition.kubescape.io APIService stays Available: False.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-apiserver-storage-ingress
+  namespace: kubescape
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: storage
+      app.kubernetes.io/name: kubescape-operator
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.18.0.0/16
+      ports:
+        - port: 443


### PR DESCRIPTION
## Summary

- The `default-deny` NetworkPolicy in the `kubescape` namespace blocked the kube-apiserver from reaching the `storage` pod on port 443
- The `v1beta1.spdx.softwarecomposition.kubescape.io` APIService has been `Available: False` since cluster bootstrap (18:42:58), causing continuous kube-apiserver errors and `prometheus-exporter` warnings every 10 seconds
- Added a targeted ingress NetworkPolicy (`allow-apiserver-storage-ingress`) that permits `ipBlock: 172.18.0.0/16` (KinD node subnet) to reach the `storage` pod on port 443

## Root Cause

The kube-apiserver calls the aggregated APIService endpoint from the host network (`172.18.0.2`). Standard Kubernetes `NetworkPolicy` cannot select host-network sources by namespace or label — only by `ipBlock`. Without this rule, the aggregated API health check always times out, leaving the APIService permanently unavailable.

## Test Plan

- [ ] `kubectl get apiservice v1beta1.spdx.softwarecomposition.kubescape.io -o jsonpath='{.status.conditions[0].status}'` returns `True` after reconciliation
- [ ] kube-apiserver logs no longer show `503` or `context deadline exceeded` for `spdx.softwarecomposition.kubescape.io`
- [ ] `prometheus-exporter` logs no longer show `failed getting configuration scan summaries`