### PR TITLE
fix(kubescape): enable offline mode to suppress missing account id errors

### DIFF
--- a/infrastructure/controllers/kubescape.yaml
+++ b/infrastructure/controllers/kubescape.yaml
@@ -51,6 +51,11 @@ spec:
       admissionController: disable
       httpDetection: disable
       seccompProfileService: disable
+      # Run without an ARMO cloud account. When disabled (the default), the
+      # operator attempts to submit scan results to api.armosec.io and logs a
+      # 400 "missing account id" error on every scan cycle because no account
+      # or accessKey is configured. Enable offline mode to suppress this.
+      kubescapeOffline: enable
     configurations:
       prometheusAnnotations: disable
 ---


### PR DESCRIPTION
## Summary

- Without an ARMO cloud account, the kubescape operator attempts to submit scan results to `api.armosec.io` on every scan cycle and logs a `400 Bad Request` "missing account id" error each time
- Added `kubescapeOffline: enable` to the HelmRelease capabilities — this puts the operator in standalone mode: scans run locally and results are stored in-cluster via the storage APIService, with no cloud submission attempted
- All local scanning capabilities (`configurationScan`, `continuousScan`, `prometheusExporter`) remain enabled

## Root Cause

The `kubescapeOffline` capability defaults to `disable` in the chart, meaning cloud submission is always attempted even when `account` and `accessKey` are empty. The fix does not require an ARMO account — it simply tells the operator not to try.

## Test Plan

- [ ] `kubectl logs -n kubescape <kubescape-pod> | grep "missing account"` returns no new entries after reconciliation
- [ ] Configuration scan results still appear in `kubectl get configurationscansummaries -A`
- [ ] Prometheus metrics from `prometheus-exporter` still expose kubescape scan data