### PR TITLE
fix(trivy): replace deprecated --slow flag with --parallel 1

### DIFF
--- a/infrastructure/controllers/trivy.yaml
+++ b/infrastructure/controllers/trivy.yaml
@@ -62,6 +62,12 @@ spec:
       # with no actionable remediation path.
       ignoreUnfixed: true
 
+      # --slow was deprecated in Trivy in favour of --parallel. Setting slow: false
+      # stops the operator from injecting the deprecated flag into scan job containers;
+      # parallel: 1 preserves the same low-resource sequential behaviour.
+      slow: false
+      parallel: 1
+
       # Resources for the scanner container inside each ephemeral scan Job pod.
       # ClientServer mode offloads DB lookups to the server, but each container
       # still pulls the image and extracts layers locally. Large images (Cilium,


### PR DESCRIPTION
## Summary

- The `trivy-operator` chart defaults `trivy.slow: true`, which injects `--slow` into every scan job container
- Trivy deprecated this flag and emits a `WARN` on every scan: `"--slow" is deprecated. Use "--parallel 1" instead.`
- Set `trivy.slow: false` to stop injecting the deprecated flag, and `trivy.parallel: 1` to preserve the same low-resource sequential scanning behaviour

## Test Plan

- [ ] New scan job container logs no longer contain `"--slow" is deprecated`
- [ ] Scan job containers show `--parallel 1` in their Trivy invocation arguments
- [ ] Vulnerability reports continue to be generated after the operator upgrades