### PR TITLE
feat(iperf3): add TCP load-testing stack through Envoy Gateway

### DIFF
--- a/apps/base/envoy-gateway/gateway.yaml
+++ b/apps/base/envoy-gateway/gateway.yaml
@@ -42,6 +42,14 @@ spec:
                   protocol: TCP
                   targetPort: 10080
                   nodePort: 30080
+                # iperf3 TCP load-testing port. nginx stream{} connects to the
+                # Envoy proxy ClusterIP on 32111 (via the stable envoy-proxy
+                # Service in proxy-service.yaml). No NodePort needed — nginx
+                # uses the ClusterIP, not the node network.
+                - name: tcp-iperf3
+                  port: 32111
+                  protocol: TCP
+                  targetPort: 32111
       envoyDeployment:
         container:
           resources:
@@ -93,3 +101,12 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: tcp-iperf3
+      port: 32111
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - group: gateway.networking.k8s.io
+            kind: TCPRoute

--- a/apps/base/iperf3/deployment.yaml
+++ b/apps/base/iperf3/deployment.yaml
@@ -1,0 +1,40 @@
+---
+# iperf3 runs in server mode (-s) on TCP port 32111.
+# Traffic arrives from the Envoy Gateway proxy via TCPRoute.
+# --forceflush flushes interval output immediately so logs are readable
+# during live load tests.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iperf3-server
+  namespace: iperf3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: iperf3-server
+  template:
+    metadata:
+      labels:
+        app: iperf3-server
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: iperf3
+          image: networkstatic/iperf3:3.17
+          args: ["-s", "-p", "32111", "--forceflush"]
+          ports:
+            - name: tcp
+              containerPort: 32111
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/apps/base/iperf3/kustomization.yaml
+++ b/apps/base/iperf3/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - route.yaml
+  - traffic-policy.yaml
+  - networkpolicies.yaml

--- a/apps/base/iperf3/namespace.yaml
+++ b/apps/base/iperf3/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: iperf3
+  labels:
+    istio-injection: disabled

--- a/apps/base/iperf3/networkpolicies.yaml
+++ b/apps/base/iperf3/networkpolicies.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: iperf3
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: iperf3
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# The Envoy proxy pods in envoy-gateway-system forward TCP connections
+# from the Gateway's tcp-iperf3 listener to this pod on port 32111.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-envoy-ingress
+  namespace: iperf3
+spec:
+  podSelector:
+    matchLabels:
+      app: iperf3-server
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: envoy-gateway-system
+      ports:
+        - port: 32111
+          protocol: TCP

--- a/apps/base/iperf3/route.yaml
+++ b/apps/base/iperf3/route.yaml
@@ -1,0 +1,18 @@
+---
+# TCPRoute wires the tcp-iperf3 listener on the main Gateway to the
+# iperf3 ClusterIP Service. The parentRef.sectionName must match the
+# listener name defined in apps/base/envoy-gateway/gateway.yaml exactly.
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: iperf3
+  namespace: iperf3
+spec:
+  parentRefs:
+    - name: main
+      namespace: envoy-ingress
+      sectionName: tcp-iperf3
+  rules:
+    - backendRefs:
+        - name: iperf3
+          port: 32111

--- a/apps/base/iperf3/service.yaml
+++ b/apps/base/iperf3/service.yaml
@@ -1,0 +1,17 @@
+---
+# ClusterIP Service — the backend target for the Envoy Gateway TCPRoute.
+# The Envoy proxy connects to this Service on port 32111 after matching
+# the tcp-iperf3 Gateway listener.
+apiVersion: v1
+kind: Service
+metadata:
+  name: iperf3
+  namespace: iperf3
+spec:
+  selector:
+    app: iperf3-server
+  ports:
+    - name: tcp
+      port: 32111
+      targetPort: 32111
+      protocol: TCP

--- a/apps/base/iperf3/traffic-policy.yaml
+++ b/apps/base/iperf3/traffic-policy.yaml
@@ -1,0 +1,35 @@
+---
+# BackendTrafficPolicy applies Envoy-level traffic shaping to the TCPRoute.
+#
+# Circuit breaker knobs:
+#   maxConnections      — Envoy drops new connections once 10 are active.
+#                         Test with: iperf3 -c localhost -p 32111 -P 20 -t 30
+#                         (-P 20 opens 20 parallel streams; connections 11-20
+#                         are rejected and visible in Envoy's upstream_cx_overflow
+#                         metric).
+#   maxPendingRequests  — Connections queued while the upstream is at capacity
+#                         beyond this limit are immediately reset.
+#
+# Timeout:
+#   connectTimeout      — Envoy closes the upstream TCP handshake attempt
+#                         after 10 s. Surfaces as connection errors in iperf3
+#                         output when the server is slow or unreachable.
+#
+# Rate limiting is HTTP-only in Envoy Gateway; it does not apply to TCPRoute.
+# Bandwidth shaping is measured by iperf3 itself (-b flag on the client).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: iperf3
+  namespace: iperf3
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: TCPRoute
+    name: iperf3
+  circuitBreaker:
+    maxConnections: 10
+    maxPendingRequests: 5
+  timeout:
+    tcp:
+      connectTimeout: 10s

--- a/apps/overlays/kind/envoy-gateway/proxy-service.yaml
+++ b/apps/overlays/kind/envoy-gateway/proxy-service.yaml
@@ -20,3 +20,7 @@ spec:
     - name: http
       port: 80
       targetPort: 10080
+    - name: tcp-iperf3
+      port: 32111
+      targetPort: 32111
+      protocol: TCP

--- a/apps/overlays/kind/istio/nodeport-proxy.yaml
+++ b/apps/overlays/kind/istio/nodeport-proxy.yaml
@@ -39,6 +39,18 @@ data:
   nginx.conf: |
     worker_processes 1;
     events {}
+    # TCP stream proxy for iperf3 load testing.
+    # KinD extraPortMapping: localhost:32111 → containerPort:9111 (TCP).
+    # nginx forwards raw TCP to the Envoy Gateway proxy ClusterIP on port
+    # 32111, where the TCPRoute picks it up for the iperf3 backend.
+    # Port 9111 is used instead of 32111 because Cilium's BPF kube-proxy
+    # replacement blocks userspace bind() on the NodePort range 30000-32767.
+    stream {
+        server {
+            listen 9111;
+            proxy_pass envoy-proxy.envoy-gateway-system.svc.cluster.local:32111;
+        }
+    }
     http {
         access_log off;
         server {
@@ -90,6 +102,7 @@ spec:
           image: nginx:1.31-alpine
           ports:
             - containerPort: 8888
+            - containerPort: 9111
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/apps/overlays/kind/kustomization.yaml
+++ b/apps/overlays/kind/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../base/tempo
   - ../../base/opentelemetry
   - ../../base/boinc
+  - ../../base/iperf3
   # Uncomment to enable:
   # - cert-manager/
   # - openebs/

--- a/infrastructure/controllers/envoy-gateway.yaml
+++ b/infrastructure/controllers/envoy-gateway.yaml
@@ -174,6 +174,12 @@ spec:
       ports:
         - port: 3000
         - port: 9090
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: iperf3
+      ports:
+        - port: 32111
 ---
 # ── envoy-ingress (nginx nodeport-proxy DaemonSet only) ──────────────────────
 apiVersion: networking.k8s.io/v1

--- a/scripts/setup-fluxcd-gitops-kind-multinode.sh
+++ b/scripts/setup-fluxcd-gitops-kind-multinode.sh
@@ -135,6 +135,14 @@ nodes:
       - containerPort: 30443
         hostPort: 8443
         protocol: TCP
+      # iperf3 TCP load-testing path:
+      #   localhost:32111  →  containerPort:9111  →  nginx stream{}
+      #   nginx  →  envoy-proxy.envoy-gateway-system.svc:32111  →  TCPRoute
+      # Port 9111 is below the NodePort range (30000-32767) so nginx can
+      # bind() on it despite Cilium's BPF socket programs blocking that range.
+      - containerPort: 9111
+        hostPort: 32111
+        protocol: TCP
   # - role: control-plane
   #   image: kindest/node:${K8S_VER}
   # - role: control-plane


### PR DESCRIPTION
## Summary

- Deploys an iperf3 server pod behind Envoy Gateway reachable from the Mac host on TCP port 32111
- Adds a `BackendTrafficPolicy` on the TCPRoute for circuit breaking, connection caps, and connect timeout — the primary traffic shaping controls at the Envoy layer
- Updates the nginx nodeport-proxy with a `stream {}` block to forward raw TCP from KinD port 9111 to the Envoy proxy ClusterIP on port 32111
- Adds a new `extraPortMapping` to the KinD setup script (`hostPort: 32111 → containerPort: 9111`)

## Traffic Path

```
localhost:32111 (Mac)
→ KinD extraPortMapping (containerPort: 9111 TCP)
→ nginx stream{} in nodeport-proxy (hostNetwork, envoy-ingress)
→ envoy-proxy.envoy-gateway-system ClusterIP:32111
→ Envoy Gateway TCPRoute (tcp-iperf3 listener)
→ iperf3-server pod:32111
```

Port 9111 is used for the KinD `containerPort` because Cilium's BPF kube-proxy replacement blocks userspace `bind()` on the NodePort range (30000–32767).

## Traffic Shaping Controls (BackendTrafficPolicy)

| Knob | Value | How to test |
|---|---|---|
| `circuitBreaker.maxConnections` | 10 | `iperf3 -c localhost -p 32111 -P 20 -t 30` — streams 11–20 hit `upstream_cx_overflow` |
| `circuitBreaker.maxPendingRequests` | 5 | Connections queued beyond 5 while upstream is saturated are immediately reset |
| `timeout.tcp.connectTimeout` | 10s | Envoy closes stalled upstream handshakes; visible as connection errors in iperf3 |

## Files Changed

**New** — `apps/base/iperf3/`: `namespace.yaml`, `deployment.yaml`, `service.yaml`, `route.yaml`, `traffic-policy.yaml`, `networkpolicies.yaml`, `kustomization.yaml`

**Modified**:
- `scripts/setup-fluxcd-gitops-kind-multinode.sh` — new `extraPortMapping`
- `apps/overlays/kind/istio/nodeport-proxy.yaml` — `stream {}` block + container port 9111
- `apps/overlays/kind/envoy-gateway/proxy-service.yaml` — port 32111 on stable ClusterIP Service
- `apps/base/envoy-gateway/gateway.yaml` — `tcp-iperf3` listener + EnvoyProxy Service port 32111
- `infrastructure/controllers/envoy-gateway.yaml` — proxy egress to `iperf3` namespace on 32111
- `apps/overlays/kind/kustomization.yaml` — adds `../../base/iperf3`

## Test Plan

- [ ] Merge this PR and recreate the cluster with `./scripts/setup-fluxcd-gitops-kind-multinode.sh`
- [ ] Verify iperf3 pod is Running: `kubectl get pods -n iperf3`
- [ ] Verify TCPRoute is accepted: `kubectl get tcproute -n iperf3 iperf3 -o jsonpath='{.status.parents[0].conditions}'`
- [ ] Raw bandwidth test: `iperf3 -c localhost -p 32111 -t 30`
- [ ] Circuit breaker test: `iperf3 -c localhost -p 32111 -P 20 -t 30`
- [ ] Observe overflow metric: `kubectl exec -n envoy-gateway-system <proxy-pod> -- curl -s localhost:19000/stats | grep cx_overflow`