### PR TITLE
fix(iperf3): use networkstatic/iperf3:multiarch tag

### DIFF
--- a/apps/base/iperf3/deployment.yaml
+++ b/apps/base/iperf3/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: iperf3
-          image: networkstatic/iperf3:3.17
+          image: networkstatic/iperf3:multiarch
           args: ["-s", "-p", "32111", "--forceflush"]
           ports:
             - name: tcp


### PR DESCRIPTION
## Summary

- `networkstatic/iperf3:3.17` does not exist on Docker Hub — only `latest` and `multiarch` tags are published for this image.
- Switches to `multiarch` tag, which provides a multi-architecture image (amd64 + arm64) and is the correct choice for the arm64 KinD cluster running on the M5 MacBook Air.

## Test plan

- [ ] Pod reaches `Running` state in the `iperf3` namespace after Flux reconciles.
- [ ] `kubectl logs -n iperf3 deploy/iperf3-server` shows iperf3 listening on port 32111.