### PR TITLE
fix(network): allow port 32111 ingress on Envoy proxy pods for iperf3 TCP traffic

### DIFF
--- a/infrastructure/controllers/envoy-gateway.yaml
+++ b/infrastructure/controllers/envoy-gateway.yaml
@@ -133,8 +133,8 @@ spec:
 ---
 # The nodeport-proxy (envoy-ingress) uses hostNetwork: true, so its traffic originates
 # from the node IP rather than a pod CIDR. Standard NetworkPolicy cannot express "from
-# host entity", so we allow all sources on the Envoy proxy's HTTP listen port. Port
-# 10080 is only reachable inside the cluster, limiting the exposure.
+# host entity", so we allow all sources on the Envoy proxy's listen ports. Ports
+# 10080 (HTTP) and 32111 (TCP iperf3) are only reachable inside the cluster.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -150,6 +150,7 @@ spec:
   ingress:
     - ports:
         - port: 10080
+        - port: 32111
 ---
 # Envoy proxy pods (in envoy-gateway-system) route HTTP traffic to backend services.
 # Ports are pod ports: Cilium's socket-level DNAT translates Service port 80 → pod


### PR DESCRIPTION
## Summary

- `allow-proxy-http-ingress` NetworkPolicy in `envoy-gateway-system` only listed port `10080` on the Envoy proxy pods.
- Port `32111` (the TCP iperf3 listener added by the Gateway's `tcp-iperf3` listener) was silently dropped by `default-deny`, causing `iperf3 -c localhost -p 32111` to fail with "Connection refused" — confirmed via `nc` timeout from inside the nginx nodeport-proxy pod.
- Adds `port: 32111` alongside `port: 10080` in the ingress allow list.

## Test plan

- [ ] After Flux reconciles, `iperf3 -c localhost -p 32111 -t 5` from the host completes without "Connection refused".
- [ ] HTTP traffic through port `8080` (Grafana, Prometheus) is unaffected.