### PR TITLE
feat(makefile): add iperf3 test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,12 @@ BOOTSTRAP_IMAGES := \
         pull-images load-images cache-running \
         check-tools status watch validate \
         sops-setup sops-load-key \
-        test-policies test-falco test-cluster test-kubescape
+        test-policies test-falco test-cluster test-kubescape \
+        test-iperf3 test-iperf3-circuit-breaker test-iperf3-overflow
 
 # ── Help ──────────────────────────────────────────────────────────────────────
 help: ## Show this help
-	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
 	  | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
 # ── Cluster lifecycle ─────────────────────────────────────────────────────────
@@ -308,3 +309,65 @@ test-cluster: ## Smoke-test a running cluster — Flux, Grafana, Prometheus, Lok
 	 [ "$$FAIL" = "0" ] \
 	   && printf '✓ Cluster smoke test passed\n\n' \
 	   || { printf '✗ Some checks failed — run: kubectl get pods -A\n\n'; exit 1; }
+
+# ── iperf3 load tests ─────────────────────────────────────────────────────────
+
+test-iperf3: ## Baseline bandwidth test — single stream, 30 s, through Envoy TCPRoute
+	@kubectl cluster-info >/dev/null 2>&1 \
+	  || { printf '\n  ✗ No cluster — run: make bootstrap\n\n'; exit 1; }
+	@kubectl get pods -n iperf3 -l app=iperf3-server --no-headers 2>/dev/null \
+	  | grep -q Running \
+	  || { printf '\n  ✗ iperf3 server not running — check: kubectl get pods -n iperf3\n\n'; exit 1; }
+	@command -v iperf3 >/dev/null 2>&1 \
+	  || { printf '\n  ✗ iperf3 not found — install: brew install iperf3\n\n'; exit 1; }
+	@printf '\n==> iperf3 baseline bandwidth test (single stream, 30 s)\n'
+	@printf '    Path: localhost:32111 → nginx stream → Envoy TCPRoute → iperf3 pod\n\n'
+	@iperf3 -4 -c localhost -p 32111 -t 30
+	@printf '\n✓ Baseline test complete\n\n'
+
+test-iperf3-circuit-breaker: ## Circuit-breaker test — 20 parallel streams; passes when upstream_cx_overflow > 0
+	@kubectl cluster-info >/dev/null 2>&1 \
+	  || { printf '\n  ✗ No cluster — run: make bootstrap\n\n'; exit 1; }
+	@kubectl get pods -n iperf3 -l app=iperf3-server --no-headers 2>/dev/null \
+	  | grep -q Running \
+	  || { printf '\n  ✗ iperf3 server not running — check: kubectl get pods -n iperf3\n\n'; exit 1; }
+	@command -v iperf3 >/dev/null 2>&1 \
+	  || { printf '\n  ✗ iperf3 not found — install: brew install iperf3\n\n'; exit 1; }
+	@printf '\n==> Circuit-breaker test: 20 parallel streams (maxConnections: 10)\n'
+	@printf '    iperf3 will report "control socket has closed unexpectedly" — that is expected.\n\n'
+	@iperf3 -4 -c localhost -p 32111 -P 20 -t 30 2>&1 || true
+	@printf '\n==> Checking Envoy upstream_cx_overflow counter...\n'
+	@PROXY_POD=$$(kubectl get pods -n envoy-gateway-system \
+	    -l app.kubernetes.io/component=proxy \
+	    -o jsonpath='{.items[0].metadata.name}'); \
+	kubectl port-forward -n envoy-gateway-system "$$PROXY_POD" 19000:19000 >/dev/null 2>&1 & PF_PID=$$!; \
+	TRIES=0; until nc -z localhost 19000 2>/dev/null || [ $$TRIES -ge 10 ]; do \
+	  sleep 1; TRIES=$$((TRIES+1)); \
+	done; \
+	OVERFLOW=$$(curl -s --max-time 5 localhost:19000/stats \
+	  | grep 'tcproute/iperf3/iperf3/rule/-1\.upstream_cx_overflow:' \
+	  | awk '{print $$2}'); \
+	kill $$PF_PID 2>/dev/null; wait $$PF_PID 2>/dev/null; \
+	printf '    upstream_cx_overflow: %s\n\n' "$${OVERFLOW:-unreadable}"; \
+	if [ -n "$$OVERFLOW" ] && [ "$$OVERFLOW" -gt 0 ]; then \
+	  printf '✓ Circuit-breaker test passed — Envoy shed %s connection(s)\n\n' "$$OVERFLOW"; \
+	else \
+	  printf '✗ Circuit-breaker did not fire — overflow counter is 0 or unreadable\n\n'; exit 1; \
+	fi
+
+test-iperf3-overflow: ## Show live Envoy circuit-breaker stats for the iperf3 cluster (read-only)
+	@kubectl cluster-info >/dev/null 2>&1 \
+	  || { printf '\n  ✗ No cluster — run: make bootstrap\n\n'; exit 1; }
+	@printf '\n==> Envoy circuit-breaker stats — tcproute/iperf3\n\n'
+	@PROXY_POD=$$(kubectl get pods -n envoy-gateway-system \
+	    -l app.kubernetes.io/component=proxy \
+	    -o jsonpath='{.items[0].metadata.name}'); \
+	kubectl port-forward -n envoy-gateway-system "$$PROXY_POD" 19000:19000 >/dev/null 2>&1 & PF_PID=$$!; \
+	TRIES=0; until nc -z localhost 19000 2>/dev/null || [ $$TRIES -ge 10 ]; do \
+	  sleep 1; TRIES=$$((TRIES+1)); \
+	done; \
+	curl -s --max-time 5 localhost:19000/stats \
+	  | grep 'tcproute/iperf3' \
+	  | grep -E 'upstream_cx_overflow|upstream_cx_total|upstream_cx_active|upstream_cx_destroy'; \
+	kill $$PF_PID 2>/dev/null; wait $$PF_PID 2>/dev/null
+	@printf '\n'


### PR DESCRIPTION
## Summary

- Adds three `test-iperf3*` targets to the Makefile, consistent with the existing `test-falco`, `test-kubescape`, and `test-cluster` pattern.
- Fixes the `help` target grep pattern (`[a-zA-Z_-]+` → `[a-zA-Z0-9_-]+`) so target names containing digits are no longer silently excluded from `make help` output.

## Targets

| Target | What it does |
|---|---|
| `make test-iperf3` | 30 s single-stream baseline test. Forces IPv4 (`-4`) to avoid the macOS `localhost → ::1` footgun. Exits 0 on clean completion. |
| `make test-iperf3-circuit-breaker` | Opens 20 parallel streams (`-P 20`) against a `maxConnections: 10` BackendTrafficPolicy. iperf3 exits non-zero ("control socket closed") — the target captures that with `|| true`, then port-forwards the Envoy admin API and checks `upstream_cx_overflow > 0`. Exits 0 when the circuit breaker fired as expected; exits 1 if the counter is zero or unreadable. |
| `make test-iperf3-overflow` | Read-only: port-forwards Envoy admin, prints `upstream_cx_overflow`, `upstream_cx_total`, `upstream_cx_active`, and `upstream_cx_destroy` for the iperf3 cluster. No pass/fail — useful for inspecting state after any test. |

## Test plan

- [ ] `make help` shows all three targets.
- [ ] `make test-iperf3` completes with 0 retransmits.
- [ ] `make test-iperf3-circuit-breaker` exits 0 and prints `upstream_cx_overflow > 0`.
- [ ] `make test-iperf3-overflow` prints the four stat lines and exits 0.