### PR TITLE
docs: full documentation audit — iperf3, Envoy 1.8.x, Elements of Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ FluxCD GitOps cluster for KinD — multi-node, Cilium CNI with kube-proxy replac
 | [Kubescape Accepted Risks](docs/kubescape-security.md) | Security findings reviewed and accepted as intentional design decisions |
 | [Istio Basic Reference](docs/ISTIO_basic_notes.md) | Day-to-day Istio administration commands |
 | [Istio Advanced Reference](docs/ISTIO_advanced_notes.md) | mTLS enforcement, authorization policy, tracing configuration |
+| [iperf3 Network Testing](docs/iperf3.md) | TCP bandwidth measurement through Envoy Gateway — network path, traffic shaping, and circuit-breaker testing |
 
 ## Repository Structure
 
@@ -92,10 +93,12 @@ homelab-gitops-k8s-2026/
 │   │   ├── tempo/                 # Grafana Tempo trace backend (single-binary, dependsOn prometheus)
 │   │   ├── opentelemetry/         # OTel Collector — OTLP ingress from Istio sidecars → Tempo export
 │   │   ├── monitoring-rules/      # PrometheusRule CRDs — separate from prometheus/ to avoid CRD ordering deadlock
-│   │   └── demo/                  # Demo workloads for mesh traffic generation
-│   │       ├── namespace.yaml     # demo namespace with istio-injection: enabled
-│   │       ├── httpbin.yaml       # httpbin Deployment + Service
-│   │       └── load-generator.yaml  # curl loop generating GET/404 traffic every 5s
+│   │   ├── demo/                  # Demo workloads for mesh traffic generation
+│   │   │   ├── namespace.yaml     # demo namespace with istio-injection: enabled
+│   │   │   ├── httpbin.yaml       # httpbin Deployment + Service
+│   │   │   └── load-generator.yaml  # curl loop generating GET/404 traffic every 5s
+│   │   ├── boinc/                 # BOINC DaemonSet — voluntary compute with SOPS-encrypted credentials
+│   │   └── iperf3/                # iperf3 server — TCPRoute via Envoy Gateway + BackendTrafficPolicy circuit-breaker
 │   └── overlays/
 │       └── kind/                  # KinD-specific composition; add patches here
 │           ├── prometheus/
@@ -110,7 +113,7 @@ homelab-gitops-k8s-2026/
 │           ├── cert-manager/      # Placeholder — uncomment in kustomization.yaml to enable
 │           ├── openebs/           # Placeholder — uncomment in kustomization.yaml to enable
 │           ├── cilium/            # Placeholder — add CiliumNetworkPolicy resources here (see note below)
-│           └── kustomization.yaml # Active: prometheus, grafana, istio, envoy-gateway, kyverno, loki, promtail, demo, tempo, opentelemetry
+│           └── kustomization.yaml # Active: prometheus, grafana, istio, envoy-gateway, kyverno, loki, promtail, demo, tempo, opentelemetry, boinc, iperf3
 │
 └── scripts/
     ├── setup-fluxcd-gitops-kind-multinode.sh  # Full 9-step cluster bootstrap
@@ -167,6 +170,8 @@ flux-system (GitRepository)
     ├── tempo                         (HelmRelease — dependsOn: kube-prometheus-stack)
     ├── opentelemetry-collector       (HelmRelease — dependsOn: kube-prometheus-stack)
     ├── demo                          (Namespace + Deployments — httpbin + load-generator, istio sidecar injected)
+    ├── boinc                         (DaemonSet — Rosetta@Home + Einstein@Home; credentials from SOPS-encrypted Secret)
+    ├── iperf3                        (Deployment + TCPRoute — TCP bandwidth testing via Envoy Gateway BackendTrafficPolicy)
     ├── istio/peerauthentication      (PeerAuthentication — mesh-wide PERMISSIVE mTLS)
     ├── istio/telemetry               (Telemetry CR — 100% sampling, extensionProvider: otel)
     ├── envoy-gateway/gateway         (EnvoyProxy CR + Gateway CR — gatewayClassName: eg)
@@ -188,8 +193,8 @@ flux-system (GitRepository)
 | istio-base | istio/base | 1.30.1 | istio-system | |
 | istiod | istio/istiod | 1.30.1 | istio-system | |
 | Gateway API CRDs | kubernetes-sigs/gateway-api | v1.2.1 | (cluster-scoped) | |
-| Envoy Gateway | envoy-gateway/gateway | 1.4.6 | envoy-gateway-system | |
-| Envoy Gateway data-plane | gatewayClassName: eg | 1.4.6 | envoy-ingress | |
+| Envoy Gateway | envoy-gateway/gateway | 1.8.1 | envoy-gateway-system | |
+| Envoy Gateway data-plane | gatewayClassName: eg | 1.8.1 | envoy-ingress | |
 | Metrics Server | metrics-server/metrics-server | 3.13.1 | metrics-server | Powers `kubectl top` and HPA; `--kubelet-insecure-tls` required for KinD |
 | kube-prometheus-stack | prometheus-community/kube-prometheus-stack | 86.2.2 | observability | |
 | Grafana | grafana/grafana | 10.5.15 | observability | |
@@ -203,6 +208,7 @@ flux-system (GitRepository)
 | Falco + Falcosidekick | falcosecurity/falco | 9.1.0 | falco | |
 | Trivy Operator | aquasecurity/trivy-operator | 0.33.1 | trivy-system | Image CVE scanning — VulnerabilityReport CRDs + Prometheus metrics; `ignoreUnfixed: true` |
 | demo (httpbin) | kennethreitz/httpbin | @sha256 digest pin | demo | No versioned tags published; pinned by digest |
+| iperf3 server | networkstatic/iperf3 | multiarch | iperf3 | TCP bandwidth measurement; BackendTrafficPolicy enforces maxConnections: 10 circuit-breaker |
 | BOINC | boinc/client | arm64v8 | boinc | Voluntary compute — Rosetta@Home + Einstein@Home; capped at 1 CPU core for thermal management |
 | Renovate | renovatebot/github-action | (GitHub Actions workflow) | — | Automated dependency PRs for Helm charts, images, GitHub Actions, and CI tool pins |
 | Gitleaks | gitleaks/gitleaks | (CI workflow pin) | — | Secret scanning on every PR — detects accidentally committed credentials before merge |
@@ -218,6 +224,7 @@ Images referenced directly in manifests (outside of Helm charts). Helm-managed w
 | `kennethreitz/httpbin` | `@sha256:599f…` | `apps/base/demo/httpbin.yaml` | HTTP echo server — mesh traffic target |
 | `curlimages/curl` | `8.20.0` | `apps/base/demo/load-generator.yaml` | Load generator: curl loop → httpbin every 5 s |
 | `nginx` | `1.31-alpine` | `apps/overlays/kind/istio/nodeport-proxy.yaml` | KinD ingress workaround: proxies host port 8888 → Envoy ClusterIP |
+| `networkstatic/iperf3` | `multiarch` | `apps/base/iperf3/deployment.yaml` | TCP bandwidth measurement server for Envoy Gateway TCPRoute testing |
 | `falcosecurity/event-generator` | `0.13.0` | `tests/falco/event-generator.yaml` | Falco live detection test job |
 
 ## Version Compatibility
@@ -229,7 +236,7 @@ The versions below were validated together. When upgrading a component, verify c
 | Kubernetes (KinD node) | v1.36.1 | `K8S_VER` in `versions.env` |
 | Cilium | 1.19.4 | `cilium.yaml` chart constraint + `versions.env` |
 | Istio | 1.30.1 | `istio.yaml` chart constraint + `versions.env` |
-| Envoy Gateway | 1.4.6 | `envoy-gateway.yaml` + `versions.env` |
+| Envoy Gateway | 1.8.1 | `envoy-gateway.yaml` + `versions.env` |
 | Gateway API CRDs | v1.2.1 | Hardcoded in `setup-fluxcd-gitops-kind-multinode.sh` step 4 |
 | kube-prometheus-stack | 86.2.2 | `prometheus/helmrelease.yaml` |
 | Loki | 7.0.0 | `loki/helmrelease.yaml` |
@@ -242,7 +249,7 @@ The versions below were validated together. When upgrading a component, verify c
 | Tetragon | 1.7.0 | `tetragon.yaml` |
 | Trivy Operator | 0.33.1 | `trivy.yaml` |
 
-All version pins shared between the Makefile and setup script are sourced from `versions.env` at the repository root — bumping them there updates both consumers.
+All version pins shared between the Makefile and setup script are sourced from `versions.env` at the repository root. Updating them there propagates the change to both consumers.
 
 ## Key Design Decisions
 
@@ -272,7 +279,7 @@ All version pins shared between the Makefile and setup script are sourced from `
 
 **No floating `latest` image tags** — Every image is pinned to a specific tag or digest. `latest` defeats drift detection and breaks rollbacks. `kennethreitz/httpbin` publishes no versioned tags, so it is pinned by digest (`@sha256:…`) instead. The `disallow-latest-image-tag` Kyverno policy accepts digest references as immutable pins.
 
-**Five-layer runtime security model** — Kyverno (admission control) validates pods before they start and audits misconfigurations. Tetragon (eBPF enforcement) can kill processes and block network connections at the syscall level. Falco (behavioral detection) continuously audits running containers and fires alerts on anomalous activity — shell spawning, sensitive file reads, credential exposure — routing them to Loki via Falcosidekick. Kubescape (compliance scanning) continuously audits the cluster's actual running state against NSA and MITRE ATT&CK frameworks and surfaces configuration drift. Trivy Operator (image CVE scanning) continuously scans every running container image and produces `VulnerabilityReport` CRDs with Prometheus metrics. The five tools are complementary: Kyverno prevents bad configuration from entering, Tetragon stops active exploitation, Falco logs suspicious activity for forensic review, Kubescape measures posture against industry frameworks, and Trivy surfaces known CVEs in the images actually running in the cluster.
+**Five-layer runtime security model** — Kyverno (admission control) validates pods before they start and audits misconfigurations. Tetragon (eBPF enforcement) can terminate processes and block network connections at the syscall level. Falco (behavioral detection) continuously audits running containers and issues alerts on anomalous activity — shell spawning, sensitive file reads, credential exposure — routing them to Loki via Falcosidekick. Kubescape (compliance scanning) continuously audits the cluster's actual running state against NSA and MITRE ATT&CK frameworks and surfaces configuration drift. Trivy Operator (image CVE scanning) continuously scans every running container image and produces `VulnerabilityReport` CRDs with Prometheus metrics. The five tools are complementary: Kyverno prevents bad configuration from entering, Tetragon stops active exploitation, Falco logs suspicious activity for forensic review, Kubescape measures posture against industry frameworks, and Trivy surfaces known CVEs in the images actually running in the cluster.
 
 **Gitleaks runs on every PR** — The `validate.yaml` CI workflow runs Gitleaks as its first step (before kustomize build or Kyverno tests) to detect accidentally committed credentials, API keys, and private key material. The version pin is tracked by Renovate via a custom regex manager so it stays current automatically.
 
@@ -306,7 +313,7 @@ The full observability stack (Prometheus, Loki, Grafana, Promtail, node-exporter
 | 24 GB | 18 GB |
 | 32 GB+ | 24 GB |
 
-Set in Docker Desktop → Settings → Resources → Memory. Below 10 GB the observability pods will OOMKill during initialization and Flux will loop in retry-remediation.
+Set this in Docker Desktop → Settings → Resources → Memory. Below 10 GB, observability pods will be terminated by the OOM killer during initialization and Flux will enter a continuous retry cycle.
 
 CPU: set to at least 4 cores. The M-series unified memory architecture means Docker Desktop allocates from the shared pool — Apple Silicon handles this transparently.
 
@@ -339,7 +346,7 @@ What it does:
 | Subsequent run after `make pull-images` | ~8–10 min |
 | Subsequent run after `make cache-running` (all images cached) | ~5–7 min |
 
-The dominant cost on the first run is image pulls. Running `make pull-images` once per version bump warms the local Docker cache; subsequent `make bootstrap` invocations skip all registry traffic for the pre-load step.
+The dominant cost on the first run is image pulls. Running `make pull-images` once per version update populates the local Docker cache; subsequent `make bootstrap` invocations skip all registry traffic for the pre-load step.
 
 To update the Flux GitRepository branch patch after creating a new branch:
 
@@ -365,7 +372,7 @@ kubectl get nodes
 # 2. All Flux resources reconciled — every row should show READY: True
 flux get all -A
 
-# 3. No pods stuck — filter out Running and Completed to spot problems
+# 3. No pods stuck — filter out Running and Completed to identify problems
 kubectl get pods -A | grep -v "Running\|Completed"
 
 # 4. Cilium CNI healthy
@@ -541,13 +548,25 @@ kubectl get workloadconfigurationscans -A
 
 ### Falco Live Detection Test (Requires: Running Cluster with Falco)
 
-Deploys the official `falcosecurity/event-generator` as a Kubernetes Job that fires the syscall action suite (reads sensitive files, spawns shells, searches for credentials). Waits for the Job to complete, then queries Falco pod logs on the same node for expected rule matches:
+Deploys the official `falcosecurity/event-generator` as a Kubernetes Job that triggers the syscall action suite (reads sensitive files, spawns shells, searches for credentials). After the Job completes, the target queries Falco pod logs on the same node for expected rule matches:
 
 ```bash
 make test-falco
 ```
 
 Checks for: `Read sensitive file untrusted`, `Run shell untrusted`, `Find AWS Credentials`, `Search Private Keys or Passwords`. Exits non-zero if any rule was not detected. Cleans up the `falco-test` namespace on completion.
+
+### iperf3 Network Tests (Requires: Running Cluster)
+
+These tests measure TCP bandwidth through the full Envoy Gateway ingress path and verify that the BackendTrafficPolicy circuit-breaker operates as configured:
+
+```bash
+make test-iperf3                    # Single-stream baseline bandwidth test
+make test-iperf3-circuit-breaker    # Verifies Envoy rejects connections above maxConnections: 10
+make test-iperf3-overflow           # Saturates the circuit breaker and expects connection refusals
+```
+
+Requires the `iperf3` CLI: `brew install iperf3`. The iperf3 server listens on port 9111 inside the cluster. The KinD `extraPortMapping` and the nginx nodeport-proxy expose it on `localhost:32111` on the host. Pass `-4` to the iperf3 client to force IPv4 and avoid connection failures from IPv6 address resolution.
 
 ## Teardown
 

--- a/docs/boinc.md
+++ b/docs/boinc.md
@@ -86,7 +86,7 @@ To update a credential:
 sops apps/base/boinc/boinc-projects-secret.yaml
 ```
 
-After saving, commit and push. Flux will reconcile the updated Secret. Restart the DaemonSet to pick up the new credentials immediately:
+After saving, commit and push. Flux will reconcile the updated Secret. Restart the DaemonSet to apply the new credentials immediately:
 
 ```bash
 kubectl rollout restart daemonset/boinc -n boinc

--- a/docs/iperf3.md
+++ b/docs/iperf3.md
@@ -42,7 +42,7 @@ iperf3 server pod  (iperf3 namespace, port 32111)
 
 ### Port 9111 instead of 32111 on the nginx DaemonSet
 
-Cilium replaces kube-proxy using BPF programs installed in the kernel. As a side effect, those programs intercept `bind()` calls on the NodePort range (30000–32767), preventing any userspace process from binding directly to a port in that range. Because the nginx DaemonSet runs with `hostNetwork: true` and must bind a port on the node's network interface, it cannot use any port in the NodePort range.
+Cilium replaces kube-proxy using BPF programs installed in the kernel. Those programs intercept `bind()` calls on the NodePort range (30000–32767), which prevents any userspace process from binding directly to a port in that range. Because the nginx DaemonSet runs with `hostNetwork: true` and must bind a port on the node's network interface, it cannot use any port in the NodePort range.
 
 Port 9111 sits below that range, so nginx binds there without conflict. The KinD cluster's `extraPortMapping` maps `hostPort 32111 → containerPort 9111`, preserving the user-facing port number on the Mac while keeping nginx clear of the NodePort range.
 
@@ -77,7 +77,7 @@ A `BackendTrafficPolicy` in `apps/base/iperf3/traffic-policy.yaml` applies a cir
 | `circuitBreaker.maxPendingRequests` | 5 | Envoy rejects pending connections once 5 are queued |
 | `timeout.tcp.connectTimeout` | 10s | Upstream connection attempt times out after 10 seconds |
 
-When `maxConnections` is exceeded, Envoy increments the `upstream_cx_overflow` counter and immediately resets the excess connections. This lets you observe circuit-breaker behaviour live using the Envoy admin API.
+When `maxConnections` is exceeded, Envoy increments the `upstream_cx_overflow` counter and immediately resets the excess connections. The circuit-breaker state can be observed in real time through the Envoy admin API.
 
 ---
 

--- a/docs/key_concepts.md
+++ b/docs/key_concepts.md
@@ -30,7 +30,7 @@ A virtual partition for grouping resources, applying access controls, and scopin
 
 ### Service
 
-A stable network endpoint that routes traffic to a set of Pods. Pods come and go; the Service IP and DNS name remain constant. Three types are used in this cluster:
+A stable network endpoint that routes traffic to a set of Pods. Pods are created and terminated continuously; the Service IP and DNS name remain constant. Three types are used in this cluster:
 
 - **ClusterIP** — reachable only inside the cluster (default)
 - **NodePort** — opens a port on every node, reachable from outside the cluster
@@ -322,7 +322,7 @@ Grafana comes pre-loaded with 16 dashboards covering Cilium, Hubble, Istio, Flux
 
 **Important note:** Symmetric encryption (AES-256, ChaCha20-Poly1305) is already quantum-safe — Grover's algorithm only halves effective key strength, leaving 256-bit keys with approximately 128 bits of security, which is considered adequate. The threat is confined to asymmetric key exchange and digital signatures.
 
-No component in this cluster can be switched to a NIST PQC algorithm today without breaking things. Every relevant tool (Age, Istio, cert-manager, Envoy) lacks stable PQC support. The `Post Quantum Computing` GitHub Actions workflow (`.github/workflows/pqc-watch.yaml`) runs weekly and creates a dashboard issue in this repository when any of the five tracked tools ships PQC support.
+No component in this cluster can be switched to a NIST PQC algorithm today without loss of compatibility. Every relevant tool — Age, Istio, cert-manager, and Envoy — lacks stable PQC support. The `Post Quantum Computing` GitHub Actions workflow (`.github/workflows/pqc-watch.yaml`) runs weekly and creates a dashboard issue in this repository when any of the five tracked tools ships PQC support.
 
 See [docs/post-quantum-readiness.md](post-quantum-readiness.md) for the complete per-component inventory, algorithm mapping, and upgrade roadmap.
 
@@ -336,3 +336,44 @@ The `demo` namespace contains two workloads that exist purely to generate traffi
 - **load-generator** (`curlimages/curl`) — sends requests to httpbin every 5 seconds, producing a continuous stream of HTTP metrics across the mesh.
 
 Without this traffic, the Istio Grafana dashboards (Mesh, Service, Workload) display empty graphs. The load-generator ensures those dashboards always contain meaningful data.
+
+---
+
+## Network Bandwidth Testing — iperf3
+
+**iperf3** is a standard network performance measurement tool. A client connects to an iperf3 server and saturates the connection with TCP or UDP traffic; the tool reports throughput, jitter, and packet loss. This cluster runs an iperf3 server as a Kubernetes `Deployment` in the `iperf3` namespace, reachable through Envoy Gateway.
+
+**Why iperf3 is included:**
+
+The iperf3 server exercises the full TCP ingress path from the macOS host:
+
+```
+Host iperf3 client (localhost:32111)
+  └─► KinD extraPortMapping → nginx nodeport-proxy (port 8888 range)
+        └─► Envoy Gateway proxy (TCPRoute on tcp-iperf3 listener)
+              └─► iperf3 Service (port 9111)
+                    └─► iperf3 Pod
+```
+
+This path tests every layer of the cluster's TCP routing configuration in a single command.
+
+**Traffic shaping — BackendTrafficPolicy:**
+
+A `BackendTrafficPolicy` resource applied to the Envoy Gateway's `iperf3` route enforces a circuit-breaker:
+
+- `maxConnections: 10` — Envoy rejects TCP connections above this limit
+- `maxPendingRequests: 5` — queued connections above this limit are rejected immediately
+- `connectTimeout: 10s` — connections that do not complete the TCP handshake within this window are closed
+
+This allows Makefile test targets (`make test-iperf3-circuit-breaker`, `make test-iperf3-overflow`) to verify that Envoy enforces capacity limits as intended.
+
+**Key resources:**
+
+| Resource | Kind | Purpose |
+|----------|------|---------|
+| `apps/base/iperf3/deployment.yaml` | Deployment + Service | iperf3 server (port 9111) |
+| `apps/base/iperf3/tcproute.yaml` | TCPRoute | Envoy Gateway routing rule |
+| `apps/base/iperf3/policy.yaml` | BackendTrafficPolicy | Circuit-breaker configuration |
+| `apps/base/iperf3/netpol.yaml` | NetworkPolicy | Default-deny with carve-outs for DNS and Envoy ingress |
+
+See [docs/iperf3.md](iperf3.md) for the complete operational guide, troubleshooting steps, and test procedures.

--- a/docs/post-quantum-readiness.md
+++ b/docs/post-quantum-readiness.md
@@ -5,7 +5,7 @@ one to the relevant NIST post-quantum standard, and gives an honest verdict on w
 be changed today vs. what requires waiting for upstream tool support.
 
 **Bottom line:** No component in this cluster can be switched to a NIST PQC algorithm
-right now without breaking things. Every tool involved — Istio, cert-manager, Age/SOPS,
+today without losing compatibility. Every tool involved — Istio, cert-manager, Age/SOPS,
 and Envoy — does not yet support the new algorithms. The value of this document is a
 clear picture of what to watch and what to change when tool support arrives.
 

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -10,7 +10,7 @@ Renovate is a bot that automatically checks if your project's dependencies — t
 
 ### Onboarding (First Run Only)
 
-The first time Renovate visits a repository, it looks for a `renovate.json` config file. If one doesn't exist, it creates a branch called `renovate/configure` and opens an **onboarding PR** that proposes a starter config. Renovate will not open any other PRs until that onboarding PR is merged — it is asking for permission before doing any work.
+The first time Renovate visits a repository, it looks for a `renovate.json` config file. If one does not exist, it creates a branch called `renovate/configure` and opens an **onboarding PR** that proposes a starter config. Renovate will not open any other PRs until that onboarding PR is merged — it requests permission before performing any update work.
 
 ### The Pipeline
 
@@ -29,7 +29,7 @@ Renovate is stateless — it does not keep a database. It re-reads your reposito
 
 | Module | Job | Analogy |
 |---|---|---|
-| **Manager** | Finds dependency files and reads what versions you're on | A reader who scans your code |
+| **Manager** | Finds dependency files and reads the currently pinned versions | A reader who scans the code |
 | **Datasource** | Contacts registries to fetch available versions | A shopper who checks the store shelves |
 | **Versioning** | Decides which versions are valid upgrades | A filter that sorts good options from bad |
 | **Platform** | Talks to GitHub/GitLab to create branches and PRs | The delivery driver who submits the update |
@@ -68,18 +68,18 @@ Automerge is gated on GitHub branch protection: the `validate` workflow (kustomi
 | Package | Reason |
 |---------|--------|
 | `boinc/client` | `arm64v8` is a Docker manifest architecture alias, not a version tag — there is no newer version to detect |
-| `kennethreitz/httpbin` | No versioned tags are published; the manifest pins the image by digest. Digest bumps produce noise with no upgrade signal |
+| `kennethreitz/httpbin` | No versioned tags are published; the manifest pins the image by digest. Digest-only updates produce noise with no meaningful upgrade signal |
 
 ---
 
 ## HelmRelease Range Constraints and Renovate
 
-Most HelmReleases in this repository use semver range constraints such as `1.17.x`. Flux resolves the latest matching chart automatically — no manual action is required for patch bumps within the range. Renovate does not create patch PRs for these because the range already covers them.
+Most HelmReleases in this repository use semver range constraints such as `1.17.x`. Flux resolves the latest matching chart automatically — no manual action is required for patch-level updates within the range. Renovate does not create patch PRs for these because the range already covers them.
 
 Renovate opens a PR only when the constraint range itself must change:
 
-- Minor bump: `1.17.x → 1.18.x` — goes into the weekly `flux-minor-updates` group PR
-- Major bump: `1.x → 2.x` — individual PR, no automerge, human review required
+- Minor update: `1.17.x → 1.18.x` — goes into the weekly `flux-minor-updates` group PR
+- Major update: `1.x → 2.x` — individual PR, no automerge, human review required
 
 ---
 

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -544,7 +544,7 @@ remote connection failure, transport failure reason: TLS_error:|268435581:SSL ro
 OPENSSL_internal:CERTIFICATE_VERIFY_FAILED
 ```
 
-**Cause:** Docker Desktop pauses the Linux VM when the Mac sleeps. Istio issues 24-hour workload certificates to each Envoy sidecar and rotates them at the 80% mark (~19 h). If the VM is frozen through that window, the rotation goroutine never fires. Once the certificate expires, Istio does not auto-renew it — the sidecar continues presenting an expired certificate until the pod is restarted.
+**Cause:** Docker Desktop pauses the Linux VM when the Mac sleeps. Istio issues 24-hour workload certificates to each Envoy sidecar and rotates them at the 80% mark (~19 h). If the VM is frozen through that rotation window, the rotation goroutine does not execute. Once the certificate expires, Istio does not auto-renew it — the sidecar continues presenting an expired certificate until the pod is restarted.
 
 **Verify:**
 
@@ -858,7 +858,7 @@ kyverno test apps/base/kyverno/tests/
 
 Expected output: `48 tests passed and 0 tests failed`.
 
-The direct `kyverno test` invocation is useful when iterating on policy changes — it prints a table showing every resource, which rule evaluated it, and whether the result matched the assertion (pass / fail / skip / excluded). The `make` wrapper is convenient for CI and quick smoke-checks.
+The direct `kyverno test` invocation is useful when revising policy — it prints a table showing every resource, which rule evaluated it, and whether the result matched the assertion (pass / fail / skip / excluded). The `make` wrapper is suitable for CI and rapid validation runs.
 
 Test layout:
 - `apps/base/kyverno/tests/kyverno-test.yaml` — 45 tests across the four validation ClusterPolicies
@@ -941,7 +941,7 @@ Requires a running cluster with Falco healthy.
 make test-falco
 ```
 
-This deploys `falcosecurity/event-generator:0.13.0` as a Job that fires the syscall action suite, then checks the Falco pod log on the same node for 4 expected rule matches. Cleans up the `falco-test` namespace on completion.
+This deploys `falcosecurity/event-generator:0.13.0` as a Job that triggers the syscall action suite, then checks the Falco pod log on the same node for 4 expected rule matches. The target removes the `falco-test` namespace on completion.
 
 ### Falco Logs
 
@@ -1336,7 +1336,7 @@ sed -i '' '/SOPS_PGP_FP/d' ~/.zshrc
 ### All Grafana Dashboards Blank After Mac Wakes from Sleep
 
 **Symptom:** Every dashboard panel shows a TLS error mentioning `CERTIFICATE_VERIFY_FAILED`.
-**Cause:** Docker Desktop's Linux VM pauses during Mac sleep, freezing Istio's cert-rotation goroutine. Workload certificates are valid for 24 h; if the rotation window is missed the sidecar presents an expired certificate until the pod restarts.
+**Cause:** Docker Desktop's Linux VM pauses during Mac sleep, which halts Istio's cert-rotation goroutine. Workload certificates are valid for 24 h; if the rotation window passes while the VM is paused, the sidecar presents an expired certificate until the pod restarts.
 **Fix:**
 
 ```bash
@@ -1755,7 +1755,7 @@ kubectl describe pod -n iperf3 <pod-name> | grep -A 5 "Events:"
 
 **Cause:** This is the circuit breaker working as designed. The `BackendTrafficPolicy` in `apps/base/iperf3/traffic-policy.yaml` sets `maxConnections: 10`. When 20 parallel streams are opened, Envoy allows 10 upstream connections and overflows the remaining 10. Terminating the excess connections while data is in flight causes iperf3 to lose its control channel.
 
-**Confirm the circuit breaker fired:**
+**Confirm the circuit breaker activated:**
 
 ```bash
 PROXY_POD=$(kubectl get pods -n envoy-gateway-system \
@@ -1795,7 +1795,7 @@ If the module is absent, the `stream {}` block in the ConfigMap will be silently
 kubectl get configmap -n envoy-ingress nodeport-proxy-conf -o yaml | grep -A 10 "stream"
 ```
 
-Restart the DaemonSet to pick up a ConfigMap change:
+Restart the DaemonSet to apply a ConfigMap change:
 
 ```bash
 kubectl rollout restart daemonset -n envoy-ingress nodeport-proxy

--- a/images/architecture.svg
+++ b/images/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="920" viewBox="0 0 1200 920">
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="990" viewBox="0 0 1200 990">
   <defs>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
       <polygon points="0 0, 8 3, 0 6" fill="#6B7280"/>
@@ -9,7 +9,7 @@
   </defs>
 
   <!-- Canvas -->
-  <rect width="1200" height="900" fill="#FAFAFA"/>
+  <rect width="1200" height="970" fill="#FAFAFA"/>
 
   <!-- Title -->
   <text x="600" y="36" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="20" font-weight="700" fill="#0F172A">homelab-gitops-k8s-2026 — Architecture Overview</text>
@@ -93,7 +93,7 @@
   <!-- Row 2 (5 boxes, w=206, gap=16) ────────────────────── -->
   <!-- Envoy Gateway -->
   <rect x="54" y="357" width="206" height="90" rx="8" fill="white" stroke="#15803D" stroke-width="2"/>
-  <text x="157" y="377" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="12" font-weight="700" fill="#15803D">Envoy Gateway 1.4.x</text>
+  <text x="157" y="377" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="12" font-weight="700" fill="#15803D">Envoy Gateway 1.8.x</text>
   <line x1="62" y1="384" x2="252" y2="384" stroke="#15803D" stroke-width="0.75" opacity="0.35"/>
   <text x="157" y="400" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9.5" fill="#475569">envoy-gateway-system</text>
   <text x="157" y="414" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9.5" fill="#475569">GatewayClass: eg · NP 30080</text>
@@ -143,11 +143,11 @@
   <!-- ══════════════════════════════════════════════════════════
        Band 3 · Applications and Observability
   ══════════════════════════════════════════════════════════ -->
-  <rect x="20" y="486" width="1160" height="282" rx="10" fill="#EFF6FF" stroke="#1E40AF" stroke-width="2"/>
+  <rect x="20" y="486" width="1160" height="352" rx="10" fill="#EFF6FF" stroke="#1E40AF" stroke-width="2"/>
   <text x="34" y="505" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#1E40AF" letter-spacing="1.2">APPLICATIONS  &amp;  OBSERVABILITY</text>
 
   <!-- Observability sub-box -->
-  <rect x="38" y="513" width="740" height="240" rx="8" fill="white" stroke="#1E40AF" stroke-width="1.5"/>
+  <rect x="38" y="513" width="740" height="310" rx="8" fill="white" stroke="#1E40AF" stroke-width="1.5"/>
   <text x="408" y="534" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="12" font-weight="700" fill="#1E40AF">observability namespace</text>
   <line x1="46" y1="540" x2="770" y2="540" stroke="#1E40AF" stroke-width="0.75" opacity="0.35"/>
 
@@ -202,8 +202,8 @@
   <text x="408" y="737" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Loki: Promtail pod logs + Falcosidekick alerts  ·  OTel Collector: OTLP spans from all Istio Envoy sidecars → Tempo</text>
 
   <!-- Demo sub-box -->
-  <rect x="796" y="513" width="366" height="240" rx="8" fill="white" stroke="#7C3AED" stroke-width="1.5"/>
-  <text x="979" y="534" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="12" font-weight="700" fill="#7C3AED">demo namespace</text>
+  <rect x="796" y="513" width="366" height="310" rx="8" fill="white" stroke="#7C3AED" stroke-width="1.5"/>
+  <text x="979" y="534" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="12" font-weight="700" fill="#7C3AED">demo  ·  iperf3 namespaces</text>
   <line x1="804" y1="540" x2="1154" y2="540" stroke="#7C3AED" stroke-width="0.75" opacity="0.35"/>
 
   <!-- httpbin chip -->
@@ -218,33 +218,38 @@
   <text x="1064" y="583" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">curl loop · GET + 404 · 5 s</text>
   <text x="1064" y="597" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">drives Istio mesh metrics</text>
 
-  <text x="979" y="625" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#7C3AED">Istio sidecar injected</text>
-  <text x="979" y="641" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">PeerAuthentication: STRICT mTLS (port 80 PERMISSIVE)</text>
-  <text x="979" y="657" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Envoy sidecars on port 15001 / 15006</text>
-  <text x="979" y="673" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">generates istio_requests_total metrics</text>
-  <text x="979" y="689" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Envoy sidecars → OTLP traces → OTel Collector</text>
+  <!-- iperf3 chip (iperf3 namespace) -->
+  <rect x="884" y="618" width="190" height="54" rx="6" fill="#FFF7ED" stroke="#C2410C" stroke-width="1.25"/>
+  <text x="979" y="636" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" font-weight="700" fill="#9A3412">iperf3 server</text>
+  <text x="979" y="651" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">networkstatic/iperf3:multiarch</text>
+  <text x="979" y="665" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">TCPRoute · BackendTrafficPolicy</text>
+
+  <text x="979" y="692" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#7C3AED">demo: Istio sidecar injected</text>
+  <text x="979" y="707" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">PeerAuthentication: STRICT mTLS (port 80 PERMISSIVE)</text>
+  <text x="979" y="722" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">generates istio_requests_total metrics → OTLP traces → OTel</text>
+  <text x="979" y="737" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">iperf3: maxConnections: 10 circuit-breaker · port 32111</text>
 
   <!-- ══════════════════════════════════════════════════════════
        Band 4 · Runtime Security (cross-cutting)
   ══════════════════════════════════════════════════════════ -->
-  <rect x="20" y="780" width="1160" height="128" rx="10" fill="#FEF2F2" stroke="#B91C1C" stroke-width="1.5" stroke-dasharray="8,4"/>
-  <text x="34" y="799" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#B91C1C" letter-spacing="1.2">RUNTIME SECURITY LAYER  ·  cross-cutting across all workloads</text>
+  <rect x="20" y="850" width="1160" height="128" rx="10" fill="#FEF2F2" stroke="#B91C1C" stroke-width="1.5" stroke-dasharray="8,4"/>
+  <text x="34" y="869" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#B91C1C" letter-spacing="1.2">RUNTIME SECURITY LAYER  ·  cross-cutting across all workloads</text>
 
-  <text x="60" y="818" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" fill="#334155">
+  <text x="60" y="888" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" fill="#334155">
     <tspan font-weight="700" fill="#B91C1C">Kyverno</tspan>
     <tspan> — validates pods at admission time (before scheduling) · Audit mode · PSS baseline · resource limits · image tag enforcement</tspan>
   </text>
-  <text x="60" y="836" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" fill="#334155">
+  <text x="60" y="906" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" fill="#334155">
     <tspan font-weight="700" fill="#B91C1C">Tetragon</tspan>
     <tspan> — eBPF kernel-level enforcement · traces process exec / network / file I/O on every node · events exported to Loki</tspan>
   </text>
-  <text x="60" y="854" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" fill="#334155">
+  <text x="60" y="924" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" fill="#334155">
     <tspan font-weight="700" fill="#B91C1C">Falco</tspan>
     <tspan> — behavioral runtime detection · shell spawning · sensitive file reads · credential exposure · alerts → Loki via Falcosidekick</tspan>
   </text>
-  <text x="60" y="872" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" fill="#334155">
+  <text x="60" y="942" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" fill="#334155">
     <tspan font-weight="700" fill="#B91C1C">Kubescape</tspan>
     <tspan> — NSA + MITRE continuous compliance scan · configurationScan + continuousScan · posture metrics on :8080 → Prometheus</tspan>
   </text>
-  <text x="600" y="898" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" font-style="italic" fill="#94A3B8">Five-layer defense: prevent (Kyverno) · enforce (Tetragon) · detect &amp; alert (Falco) · audit posture (Kubescape) · scan CVEs (Trivy)</text>
+  <text x="600" y="968" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" font-style="italic" fill="#94A3B8">Five-layer defense: prevent (Kyverno) · enforce (Tetragon) · detect &amp; alert (Falco) · audit posture (Kubescape) · scan CVEs (Trivy)</text>
 </svg>

--- a/images/flow.svg
+++ b/images/flow.svg
@@ -220,13 +220,13 @@
   <text x="512" y="757" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">0.x · OTLP → Tempo</text>
   <text x="512" y="769" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">dependsOn: prometheus</text>
 
-  <!-- demo workloads -->
+  <!-- demo + iperf3 workloads -->
   <rect x="577" y="675" width="148" height="90" rx="6" fill="white" stroke="#7C3AED" stroke-width="1.5"/>
-  <text x="651" y="693" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#6D28D9">demo workloads</text>
+  <text x="651" y="693" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#6D28D9">demo · iperf3 workloads</text>
   <text x="651" y="708" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">httpbin + load-generator</text>
-  <text x="651" y="722" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Istio sidecar injected</text>
-  <text x="651" y="736" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">namespace: demo</text>
-  <text x="651" y="750" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">STRICT mTLS (port 80 PERM)</text>
+  <text x="651" y="722" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Istio sidecar · STRICT mTLS</text>
+  <text x="651" y="736" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">iperf3 server · TCPRoute</text>
+  <text x="651" y="750" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">BackendTrafficPolicy circuit-breaker</text>
 
   <!-- Mesh + Ingress config CRs -->
   <rect x="735" y="675" width="128" height="90" rx="6" fill="white" stroke="#EA580C" stroke-width="1.5"/>

--- a/images/network-topology.svg
+++ b/images/network-topology.svg
@@ -58,7 +58,7 @@
   ══════════════════════════════════════════════════ -->
   <rect x="34" y="203" width="320" height="270" rx="8" fill="#FFF7ED" stroke="#C2410C" stroke-width="1.5"/>
   <text x="194" y="221" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#C2410C">control-plane node</text>
-  <text x="194" y="235" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">kindest/node:v1.35.0</text>
+  <text x="194" y="235" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">kindest/node:v1.36.1</text>
 
   <!-- nginx nodeport-proxy box -->
   <rect x="50" y="243" width="288" height="58" rx="6" fill="white" stroke="#EA580C" stroke-width="1.5"/>
@@ -94,7 +94,7 @@
   ══════════════════════════════════════════════════ -->
   <rect x="374" y="203" width="232" height="286" rx="8" fill="#F0FDF4" stroke="#15803D" stroke-width="1.5"/>
   <text x="490" y="221" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#15803D">worker-1 node</text>
-  <text x="490" y="235" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">kindest/node:v1.35.0</text>
+  <text x="490" y="235" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">kindest/node:v1.36.1</text>
 
   <rect x="390" y="243" width="200" height="50" rx="6" fill="white" stroke="#C2410C" stroke-width="1.25"/>
   <text x="490" y="260" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#C2410C">Cilium (eBPF)</text>
@@ -122,7 +122,7 @@
   ══════════════════════════════════════════════════ -->
   <rect x="624" y="203" width="232" height="286" rx="8" fill="#F0FDF4" stroke="#15803D" stroke-width="1.5"/>
   <text x="740" y="221" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#15803D">worker-2 node</text>
-  <text x="740" y="235" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">kindest/node:v1.35.0</text>
+  <text x="740" y="235" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">kindest/node:v1.36.1</text>
 
   <rect x="640" y="243" width="200" height="50" rx="6" fill="white" stroke="#C2410C" stroke-width="1.25"/>
   <text x="740" y="260" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#C2410C">Cilium (eBPF)</text>
@@ -157,12 +157,13 @@
   <text x="179" y="554" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8" font-style="italic">Hubble UI: disabled (saves ~200 Mi RAM)</text>
 
   <!-- envoy-ingress namespace -->
-  <rect x="338" y="490" width="290" height="70" rx="8" fill="#FFF7ED" stroke="#EA580C" stroke-width="1.25"/>
-  <text x="483" y="507" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#C2410C">envoy-ingress namespace</text>
+  <rect x="338" y="490" width="290" height="84" rx="8" fill="#FFF7ED" stroke="#EA580C" stroke-width="1.25"/>
+  <text x="483" y="507" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#C2410C">envoy-ingress · iperf3 namespaces</text>
   <line x1="346" y1="513" x2="620" y2="513" stroke="#EA580C" stroke-width="0.75" opacity="0.35"/>
   <text x="483" y="528" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Envoy Gateway proxy Deployment</text>
   <text x="483" y="542" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">NodePort Service :30080 (→ localhost:8080)</text>
-  <text x="483" y="554" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">HTTPRoute: grafana.local · prometheus.local</text>
+  <text x="483" y="556" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">HTTPRoute: grafana.local · prometheus.local</text>
+  <text x="483" y="570" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#C2410C">TCPRoute: iperf3 :32111 → iperf3 ns (circuit-breaker)</text>
 
   <!-- flux-system + cert-manager etc -->
   <rect x="642" y="490" width="424" height="70" rx="8" fill="#EEF2FF" stroke="#4F46E5" stroke-width="1.25"/>
@@ -218,17 +219,18 @@
   <text x="930" y="728" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" fill="#334155">OTLP traces (Envoy → OTel)</text>
 
   <!-- Ingress path label -->
-  <text x="34" y="590" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#EA580C">Ingress path:</text>
-  <text x="34" y="605" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">localhost:8080 → KinD containerPort:8888 → nginx (hostNetwork) → envoy-proxy ClusterIP → HTTPRoute → Service</text>
-  <text x="34" y="620" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8" font-style="italic">nginx workaround required: Cilium BPF blocks bind() on NodePort range 30000–32767 on macOS/Docker Desktop</text>
+  <text x="34" y="592" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#EA580C">HTTP ingress path:</text>
+  <text x="34" y="606" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">localhost:8080 → KinD containerPort:8888 → nginx (hostNetwork) → envoy-proxy ClusterIP → HTTPRoute → Service</text>
+  <text x="34" y="619" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#C2410C">TCP ingress path (iperf3):</text>
+  <text x="34" y="633" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">localhost:32111 → KinD containerPort:9111 → nginx stream block → envoy-proxy :32111 → TCPRoute → iperf3 Service</text>
 
   <!-- OTLP trace path -->
-  <text x="34" y="638" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#0D9488">OTLP trace path:</text>
-  <text x="34" y="653" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Istio Envoy sidecars (demo + observability) → OTLP gRPC :4317 → OTel Collector → Tempo (stores) → Grafana (queries :3200)</text>
+  <text x="34" y="648" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#0D9488">OTLP trace path:</text>
+  <text x="34" y="662" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Istio Envoy sidecars (demo + observability) → OTLP gRPC :4317 → OTel Collector → Tempo (stores) → Grafana (queries :3200)</text>
 
   <!-- Network config summary -->
-  <text x="34" y="668" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#C2410C">Cilium CNI config:</text>
-  <text x="34" y="682" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">routingMode: tunnel · tunnelProtocol: vxlan  ·  bpf.masquerade: false (Docker bridge does its own NAT)</text>
-  <text x="34" y="696" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">ipam.mode: kubernetes (honours KinD podSubnet 10.244.0.0/16)  ·  socketLB.hostNamespaceOnly: true (Envoy sidecar port safe)</text>
-  <text x="34" y="710" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">kubeProxyReplacement: true  ·  k8sServiceHost: flux-kind-control-plane  ·  k8sServicePort: 6443</text>
+  <text x="34" y="677" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#C2410C">Cilium CNI config:</text>
+  <text x="34" y="691" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">routingMode: tunnel · tunnelProtocol: vxlan  ·  bpf.masquerade: false (Docker bridge does its own NAT)</text>
+  <text x="34" y="705" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">ipam.mode: kubernetes (honours KinD podSubnet 10.244.0.0/16)  ·  socketLB.hostNamespaceOnly: true (Envoy sidecar port safe)</text>
+  <text x="34" y="719" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">kubeProxyReplacement: true  ·  k8sServiceHost: flux-kind-control-plane  ·  k8sServicePort: 6443</text>
 </svg>

--- a/infrastructure/controllers/envoy-gateway.yaml
+++ b/infrastructure/controllers/envoy-gateway.yaml
@@ -9,7 +9,7 @@ metadata:
     istio-injection: disabled
 ---
 # envoy-ingress holds only the nginx nodeport-proxy DaemonSet (KinD port-mapping shim).
-# Envoy Gateway auto-provisions the data-plane proxy pod in envoy-gateway-system (1.4.x).
+# Envoy Gateway auto-provisions the data-plane proxy pod in envoy-gateway-system (1.8.x).
 # Injection disabled: Envoy Gateway manages its own Envoy proxies; Istio sidecar
 # injection would conflict with the gateway container lifecycle.
 apiVersion: v1
@@ -46,7 +46,7 @@ spec:
   chart:
     spec:
       chart: gateway-helm
-      version: "1.4.x"
+      version: "1.8.x"
       sourceRef:
         kind: HelmRepository
         name: envoy-gateway


### PR DESCRIPTION
## Summary

- **Envoy Gateway upgrade**: HelmRelease chart constraint updated from `1.4.x` to `1.8.x` to match the `v1.8.1` pin already present in `versions.env`
- **iperf3 documentation**: Added to README docs table, repo structure tree, dependency chain, deployed components table, container images table, testing section, and a new section in `docs/key_concepts.md`
- **Elements of Style overhaul**: Removed all contractions and informal phrasing across `README.md`, `docs/boinc.md`, `docs/iperf3.md`, `docs/key_concepts.md`, `docs/post-quantum-readiness.md`, `docs/renovate.md`, and `docs/troubleshooting-guide.md`; formal tone and tenth-grade reading level applied throughout
- **SVG diagram updates**: `architecture.svg` adds an iperf3 chip and updates Envoy Gateway to 1.8.x; `flow.svg` updates the demo workloads box to include iperf3; `network-topology.svg` adds iperf3 to the envoy-ingress namespace box, adds a TCP ingress path annotation, and corrects the KinD node version label from `v1.35.0` to `v1.36.1`

## Test plan

- [ ] CI `validate.yaml` passes: kustomize build, Kyverno policy tests, Kubescape scan
- [ ] Verify no contractions in docs: `grep -rE "\b(don't|won't|can't|it's|doesn't|isn't)\b" README.md docs/`
- [ ] Verify Envoy Gateway constraint: `grep version: infrastructure/controllers/envoy-gateway.yaml` → `1.8.x`
- [ ] Verify iperf3 entries in README: `grep iperf3 README.md`
- [ ] Open architecture.svg in a browser to confirm iperf3 chip renders in the Applications layer