### PR TITLE
fix(metrics-server): correct NetworkPolicy ingress port from 4443 to 10250

### DIFF
--- a/infrastructure/controllers/metrics-server.yaml
+++ b/infrastructure/controllers/metrics-server.yaml
@@ -142,7 +142,7 @@ spec:
     - Ingress
   ingress:
     - ports:
-        - port: 4443
+        - port: 10250
 ---
 # Metrics Server scrapes kubelet /stats/summary on port 10250 to collect
 # node and pod resource usage. Kubelets run on node IPs (not in any namespace),


### PR DESCRIPTION
## Summary

- `metrics-server-allow-apiserver-ingress` NetworkPolicy had port `4443` — a holdover from older metrics-server Helm chart versions
- Current chart (0.8.1) serves its HTTPS extension API on port `10250`
- Cilium enforced `default-deny` at the pod level, dropping kube-apiserver discovery probes silently
- The `v1beta1.metrics.k8s.io` APIService entered `FailedDiscoveryCheck` state, making `kubectl top` and HPA unavailable

## Test plan

- [x] Patched NetworkPolicy on the running cluster and confirmed `kubectl get apiservice v1beta1.metrics.k8s.io` reports `status: True` / `all checks passed`
- [x] `kubectl top nodes` returns CPU and memory readings for all three KinD nodes