### PR TITLE
feat(iperf3): add feature flag — make iperf3-enable / make iperf3-disable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,3 +371,19 @@ test-iperf3-overflow: ## Show live Envoy circuit-breaker stats for the iperf3 cl
 	  | grep -E 'upstream_cx_overflow|upstream_cx_total|upstream_cx_active|upstream_cx_destroy'; \
 	kill $$PF_PID 2>/dev/null; wait $$PF_PID 2>/dev/null
 	@printf '\n'
+
+# ── iperf3 feature flag ───────────────────────────────────────────────────────
+
+iperf3-enable: ## Enable iperf3 — uncomments its entry in apps/overlays/kind/kustomization.yaml
+	@sed -i '' 's|^  # - ../../base/iperf3.*|  - ../../base/iperf3|' \
+	  apps/overlays/kind/kustomization.yaml
+	@grep -q '^  - ../../base/iperf3$$' apps/overlays/kind/kustomization.yaml \
+	  && printf '\n✓ iperf3 enabled in apps/overlays/kind/kustomization.yaml\n  Commit and push to deploy via Flux.\n\n' \
+	  || { printf '\n✗ Pattern not matched — inspect apps/overlays/kind/kustomization.yaml\n\n'; exit 1; }
+
+iperf3-disable: ## Disable iperf3 — comments out its entry in apps/overlays/kind/kustomization.yaml
+	@sed -i '' 's|^  - ../../base/iperf3$$|  # - ../../base/iperf3        # iperf3 feature flag — run: make iperf3-enable to restore|' \
+	  apps/overlays/kind/kustomization.yaml
+	@grep -q '^  # - ../../base/iperf3' apps/overlays/kind/kustomization.yaml \
+	  && printf '\n✓ iperf3 disabled in apps/overlays/kind/kustomization.yaml\n  Commit and push to remove via Flux (prune: true will delete the namespace).\n\n' \
+	  || { printf '\n✗ Pattern not matched — inspect apps/overlays/kind/kustomization.yaml\n\n'; exit 1; }

--- a/apps/overlays/kind/kustomization.yaml
+++ b/apps/overlays/kind/kustomization.yaml
@@ -13,8 +13,8 @@ resources:
   - ../../base/tempo
   - ../../base/opentelemetry
   - ../../base/boinc
-  - ../../base/iperf3
   # Uncomment to enable:
+  # - ../../base/iperf3        # iperf3 feature flag — run: make iperf3-enable to restore
   # - cert-manager/
   # - openebs/
   # - cilium/   # placeholder for CiliumNetworkPolicy resources; the CNI


### PR DESCRIPTION
## Summary

- iperf3 is a bandwidth-testing tool, not a persistent workload — it should be off by default
- Moves `../../base/iperf3` from the active resources list to the commented \"Uncomment to enable\" block in `apps/overlays/kind/kustomization.yaml`, matching the existing pattern used for `cert-manager` and `openebs`
- Adds two Makefile targets that sed-toggle the comment in place:
  - `make iperf3-enable` — uncomments the line; commit and push to deploy via Flux
  - `make iperf3-disable` — comments it back out; commit and push to prune via Flux (`prune: true` on the apps Kustomization handles namespace deletion)

## Test plan

- [ ] `make iperf3-enable` — verify kustomization.yaml line becomes active, message printed
- [ ] `make iperf3-disable` — verify line is commented back out, message printed
- [ ] Round-trip: enable → disable → enable produces a valid kustomization each time
- [ ] With a running cluster: enable → commit/push → `flux reconcile kustomization apps --with-source` → `kubectl get ns iperf3` shows namespace created
- [ ] Disable → commit/push → reconcile → `kubectl get ns iperf3` shows namespace gone