### PR TITLE
fix(boinc): inject global_prefs_override.xml to disable suspend_cpu_usage

### DIFF
--- a/apps/base/boinc/daemonset.yaml
+++ b/apps/base/boinc/daemonset.yaml
@@ -27,6 +27,8 @@ spec:
                      /var/lib/boinc/account_boinc.bakerlab.org_rosetta.xml
               cp -n /boinc-account-init/account_einstein.phys.uwm.edu.xml \
                      /var/lib/boinc/account_einstein.phys.uwm.edu.xml
+              cp /boinc-prefs-override/global_prefs_override.xml \
+                 /var/lib/boinc/global_prefs_override.xml
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -43,6 +45,9 @@ spec:
               mountPath: /var/lib/boinc
             - name: boinc-projects
               mountPath: /boinc-account-init
+              readOnly: true
+            - name: boinc-prefs-override
+              mountPath: /boinc-prefs-override
               readOnly: true
       containers:
         - name: boinc
@@ -81,3 +86,6 @@ spec:
         - name: boinc-projects
           secret:
             secretName: boinc-projects-secret
+        - name: boinc-prefs-override
+          configMap:
+            name: boinc-global-prefs-override

--- a/apps/base/boinc/global-prefs-override-configmap.yaml
+++ b/apps/base/boinc/global-prefs-override-configmap.yaml
@@ -1,0 +1,21 @@
+---
+# Overrides the global_prefs.xml delivered by Einstein@Home's scheduler.
+# BOINC merges this file on top of server prefs at startup, so only the
+# keys listed here are overridden; everything else retains its server value.
+#
+# suspend_cpu_usage: 0  disables the "suspend when CPU is busy" policy.
+# Inside a KinD container, BOINC reads /proc/stat from the host machine
+# (the Mac), not the container cgroup, so it sees the Mac's total CPU load
+# and repeatedly suspends itself even though the container is the source
+# of that load. Setting the threshold to 0 (disabled) eliminates the
+# spurious suspend/resume loop without affecting the container CPU limit.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: boinc-global-prefs-override
+  namespace: boinc
+data:
+  global_prefs_override.xml: |
+    <global_preferences>
+      <suspend_cpu_usage>0</suspend_cpu_usage>
+    </global_preferences>

--- a/apps/base/boinc/kustomization.yaml
+++ b/apps/base/boinc/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - daemonset.yaml
   - boinc-projects-secret.yaml
   - netpol.yaml
+  - global-prefs-override-configmap.yaml


### PR DESCRIPTION
## Problem

Both BOINC pods showed a repeated `Suspending computation - CPU is busy` / `Resuming computation` cycle every 2–5 minutes. The pods were doing real work (completing and reporting Einstein@Home tasks) but spending significant time suspended.

Root cause: BOINC reads `/proc/stat` to measure system CPU load. Inside a KinD container, `/proc/stat` is the **host machine's** (Mac's) counters, not the container cgroup. The `suspend_cpu_usage: 25` preference in `global_prefs.xml` (delivered by Einstein@Home's scheduler) caused BOINC to suspend whenever the Mac's aggregate CPU exceeded 25% — which BOINC itself was causing.

## Fix

Add a `ConfigMap` (`boinc-global-prefs-override`) containing a minimal `global_prefs_override.xml`:

```xml
<global_preferences>
  <suspend_cpu_usage>0</suspend_cpu_usage>
</global_preferences>
```

BOINC merges this override on top of the server-delivered prefs at startup. Setting `suspend_cpu_usage=0` disables the threshold entirely. The container CPU limit (1000m) remains the real governor — no change to resource requests/limits.

The existing `boinc-account-init` init container copies the file into `/var/lib/boinc/` on every pod start, so the override survives scheduler preference syncs (which only update `global_prefs.xml`, not `global_prefs_override.xml`).

## Test plan

- [ ] After rollout: `kubectl logs -n boinc <pod> --follow` — verify no more `Suspending computation - CPU is busy` lines
- [ ] `kubectl exec -n boinc <pod> -- cat /var/lib/boinc/global_prefs_override.xml` — confirm file present with `suspend_cpu_usage=0`
- [ ] `kubectl top pods -n boinc` — expect CPU closer to the 1000m limit (no more artificial pauses)