### PR TITLE
fix(nodeport-proxy): correct Contour service name; defer DNS with resolver+variable

### DIFF
--- a/apps/overlays/kind/istio/nodeport-proxy.yaml
+++ b/apps/overlays/kind/istio/nodeport-proxy.yaml
@@ -53,14 +53,21 @@ data:
     }
     http {
         access_log off;
+        # Defer upstream DNS resolution to request time rather than startup.
+        # Without this, nginx crashes on boot if any proxy_pass hostname is
+        # unresolvable — taking down every route. With a resolver + variable,
+        # nginx starts regardless; unresolvable upstreams return 502 per-request
+        # instead of bringing down the whole proxy.
+        resolver 10.96.0.10 valid=10s ipv6=off;
         # Contour ingress stack — routes traffic to Contour's Envoy data plane.
-        # The envoy Service in the contour namespace exposes port 80 → pod port 8080.
-        # This block must precede the catch-all server_name _ block.
+        # Service name: contour-contour-envoy (Helm release name prefix = contour-contour).
+        # Must precede the catch-all server_name _ block.
         server {
             listen 8888;
             server_name httpbin-contour.local;
             location / {
-                proxy_pass         http://envoy.contour.svc.cluster.local:80;
+                set $contour_upstream http://contour-contour-envoy.contour.svc.cluster.local:80;
+                proxy_pass         $contour_upstream;
                 proxy_http_version 1.1;
                 proxy_set_header   Host              $host;
                 proxy_set_header   X-Real-IP         $remote_addr;
@@ -73,7 +80,8 @@ data:
             listen 8888;
             server_name _;
             location / {
-                proxy_pass         http://envoy-proxy.envoy-gateway-system.svc.cluster.local;
+                set $egw_upstream http://envoy-proxy.envoy-gateway-system.svc.cluster.local;
+                proxy_pass         $egw_upstream;
                 proxy_http_version 1.1;
                 proxy_set_header   Host              $host;
                 proxy_set_header   X-Real-IP         $remote_addr;


### PR DESCRIPTION
## Problem

The nginx nodeport-proxy entered `CrashLoopBackOff` after the Contour changes in PR #72, taking down **all** ingress routes — including the existing Envoy Gateway routes for Grafana and Prometheus (both returning HTTP 000).

Two bugs combined to cause this:

### Bug 1 — Wrong Contour service name
The nginx config used `envoy.contour.svc.cluster.local:80`, but the Contour Helm chart creates the Envoy Service with a release-name prefix: `contour-contour-envoy`. DNS lookup failed immediately.

### Bug 2 — nginx DNS resolution at startup (structural)
nginx resolves all `proxy_pass` hostnames **at startup**, not at request time. If any DNS lookup fails — for any upstream, including ones for other routes — the entire process crashes. This is why the Contour misconfiguration also broke Grafana and Prometheus.

## Fix

**Fix 1:** Correct the Contour upstream hostname:
```
envoy.contour.svc.cluster.local           ← wrong
contour-contour-envoy.contour.svc.cluster.local  ← correct
```

**Fix 2:** Add `resolver 10.96.0.10 valid=10s ipv6=off` and convert both `proxy_pass` directives to use `$variables`. With a variable, nginx defers DNS resolution to request time. An unresolvable upstream now returns 502 per-request rather than crashing the proxy — critical during bootstrap when upstreams may not all be ready simultaneously.

## Verification

After merge + Flux reconcile:
- [ ] `kubectl get pods -n envoy-ingress` shows nodeport-proxy `Running 1/1`
- [ ] `curl -H "Host: grafana.local" http://localhost:8080/` returns `302`
- [ ] `curl -H "Host: httpbin-contour.local" http://localhost:8080/get` returns `200`