### PR TITLE
fix(contour): correct NetworkPolicy selectors; fix nginx default_server

### DIFF
--- a/apps/overlays/kind/istio/nodeport-proxy.yaml
+++ b/apps/overlays/kind/istio/nodeport-proxy.yaml
@@ -76,8 +76,12 @@ data:
             }
         }
         # Envoy Gateway ingress stack — catch-all for all other hostnames.
+        # default_server is required: server_name _ is an invalid DNS name that
+        # matches nothing. Without default_server, nginx falls back to the FIRST
+        # defined server block for unmatched hosts — which would be the Contour
+        # block, breaking Grafana and Prometheus routes.
         server {
-            listen 8888;
+            listen 8888 default_server;
             server_name _;
             location / {
                 set $egw_upstream http://envoy-proxy.envoy-gateway-system.svc.cluster.local;

--- a/infrastructure/controllers/contour.yaml
+++ b/infrastructure/controllers/contour.yaml
@@ -156,7 +156,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: envoy
+      app.kubernetes.io/component: envoy
   policyTypes:
     - Ingress
   ingress:
@@ -173,7 +173,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: envoy
+      app.kubernetes.io/component: envoy
   policyTypes:
     - Egress
   egress:


### PR DESCRIPTION
## Summary

Live cluster verification (via the verify skill) found two bugs introduced with the Contour integration that cause 504 on all routes — including the pre-existing Envoy Gateway routes for Grafana and Prometheus.

---

## Bug 1 — NetworkPolicy pod selectors wrong (`infrastructure/controllers/contour.yaml`)

Both `allow-envoy-http-ingress` and `allow-envoy-egress-to-backends` used:
```yaml
podSelector:
  matchLabels:
    app.kubernetes.io/name: envoy   # ← wrong
```

The Contour chart (Bitnami-maintained) labels its Envoy DaemonSet pods with `app.kubernetes.io/name: contour` (the chart/release name) and `app.kubernetes.io/component: envoy` (the role). Zero pods matched either policy, so:
- All ingress to the Contour Envoy data plane on port 8080 was blocked by `default-deny`
- All egress from Contour Envoy to `httpbin` in the `demo` namespace was blocked

**Fix:** selector changed to `app.kubernetes.io/component: envoy`

---

## Bug 2 — nginx `default_server` missing (`apps/overlays/kind/istio/nodeport-proxy.yaml`)

`server_name _` is an invalid DNS name — it does not act as a wildcard in nginx. Without the `default_server` parameter on the `listen` directive, nginx routes any `Host` header that matches no `server_name` to the **first defined server block**. The Contour block (`server_name httpbin-contour.local`) was defined first, so requests for `grafana.local` and `prometheus.local` were sent to `contour-contour-envoy` (10.108.139.91), which timed out due to Bug 1.

Evidence from nginx error log:
```
upstream timed out while connecting to upstream,
server: httpbin-contour.local,      ← wrong server block selected
upstream: "http://10.108.139.91:80/",   ← Contour Envoy, not Envoy Gateway
host: "grafana.local"               ← should have gone to EGW
```

**Fix:** added `default_server` to the Envoy Gateway catch-all listen directive

---

## Test plan

After merge + Flux reconcile:
- [ ] `kubectl get netpol -n contour allow-envoy-http-ingress -o yaml` shows `app.kubernetes.io/component: envoy`
- [ ] `curl -H "Host: grafana.local" http://localhost:8080/` returns `302`
- [ ] `curl -H "Host: prometheus.local" http://localhost:8080/` returns `200`
- [ ] `curl -H "Host: httpbin-contour.local" http://localhost:8080/get` returns `200`
- [ ] `curl -H "Host: unknown.local" http://localhost:8080/` returns `404` (Envoy Gateway no-match, not Contour timeout)