### PR TITLE
fix(kyverno): exclude cilium-test-* namespaces from Enforce policies

### DIFF
--- a/apps/base/kyverno/policies.yaml
+++ b/apps/base/kyverno/policies.yaml
@@ -71,6 +71,11 @@ spec:
                 # kube-controller-manager) and CNI (cilium, cilium-envoy) require
                 # hostNetwork, hostPath, and elevated capabilities by design.
                 - kube-system
+                # cilium connectivity test creates ephemeral namespaces
+                # (cilium-test-1, cilium-test-2) with privileged test pods that
+                # do not conform to the Baseline profile. These are transient
+                # diagnostic workloads, not production deployments.
+                - cilium-test-*
       validate:
         podSecurity:
           level: baseline
@@ -189,6 +194,10 @@ spec:
                 # data-plane Envoy, shutdown-manager) have explicit limits set via
                 # deployment.envoyGateway.resources and envoyDeployment.patch.
                 - envoy-gateway-system
+                # cilium connectivity test creates ephemeral namespaces
+                # (cilium-test-1, cilium-test-2) with test pods that have no
+                # resource limits. These are transient diagnostic workloads.
+                - cilium-test-*
       validate:
         message: "All containers must declare cpu and memory requests and limits."
         foreach:
@@ -262,6 +271,10 @@ spec:
                 # kube-apiserver etc.) omit securityContext entirely, causing
                 # JMESPath eval errors. These are privileged by design.
                 - kube-system
+                # cilium connectivity test deploys pods without a securityContext,
+                # causing a JMESPath eval error on the allowPrivilegeEscalation
+                # lookup ("Unknown key"). These are ephemeral test workloads.
+                - cilium-test-*
       validate:
         message: "All containers must set securityContext.allowPrivilegeEscalation: false."
         foreach:


### PR DESCRIPTION
## Problem

`cilium connectivity test` was blocked at admission by two `Enforce`-mode Kyverno policies:

```
disallow-privilege-escalation:
  autogen-check-privilege-escalation: 'JMESPath query failed:
    Unknown key "allowPrivilegeEscalation" in path'

require-resource-limits:
  autogen-check-container-resources: 'All containers must declare
    cpu and memory requests and limits.'
```

The connectivity test creates ephemeral namespaces (`cilium-test-1`, `cilium-test-2`) and deploys workloads (echo servers, DNS test pods) with neither a `securityContext` nor `resources.limits`. These are Cilium-controlled test utilities and cannot be configured by users.

## Fix

Added `cilium-test-*` to the namespace exclusion list on all three policies:

| Policy | Mode | Why excluded |
|---|---|---|
| `disallow-privilege-escalation` | **Enforce** | Test pods omit `securityContext` entirely; JMESPath eval errors on the missing `allowPrivilegeEscalation` key block admission |
| `require-resource-limits` | **Enforce** | Test pods have no `resources.limits`; blocked at admission |
| `pod-security-baseline` | Audit | Suppresses noise in policy reports |

The wildcard pattern `cilium-test-*` covers both `cilium-test-1` (single-node) and `cilium-test-2` (multi-node) without hardcoding individual names.

## Test plan

- [ ] CI (`validate` workflow) passes — Kyverno offline tests still pass
- [ ] After merge and Flux reconciliation: `cilium connectivity test` completes without admission webhook errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)