### PR TITLE
fix(cilium): disable monitor aggregation for full Hubble flow visibility

### DIFF
--- a/infrastructure/controllers/cilium.yaml
+++ b/infrastructure/controllers/cilium.yaml
@@ -94,6 +94,12 @@ spec:
     # correctly and restores external DNS resolution.
     bpf:
       masquerade: false
+      # none: emit a flow event for every packet; required for cilium connectivity
+      # test's Hubble flow-validation steps (pod-to-service, pod-to-itself-via-service)
+      # to observe Service ClusterIP flows. At medium (default), per-connection events
+      # for ClusterIP traffic are aggregated away, leaving Hubble with zero matches.
+      # The performance cost is negligible on a three-node KinD cluster.
+      monitorAggregation: none
 
     # ── IPAM ─────────────────────────────────────────────────────────────────
     ipam:


### PR DESCRIPTION
## Summary

- Sets `bpf.monitorAggregation: none` in the Cilium HelmRelease so that every flow event is emitted to the Hubble observer
- Fixes three failing scenarios in `cilium connectivity test`: `no-policies/pod-to-service`, `allow-all-except-world/pod-to-service`, and `pod-to-itself-via-service`

## Root cause

At the default `medium` aggregation level, Cilium's eBPF programs only emit flow events for connection establishment and teardown, aggregating away per-packet events for established TCP connections. For Service ClusterIP traffic, the Hubble ring buffer ends up with zero matching events — Hubble records flows to the backend pod IP (post-DNAT) rather than the Service IP the test queries for, or the aggregation window silently drops the events.

The connectivity test detects aggregation and skips some flow validation steps, but the pod-to-service and pod-to-itself-via-service scenarios still query Hubble and receive zero results (`first: -1, last: -1, matched: 0`).

Setting `monitorAggregation: none` forces every packet to emit a flow event, giving Hubble complete visibility. The performance cost is negligible on a three-node KinD cluster.

## Also fixed (via DaemonSet restart)

The `check-log-errors` test found a config drift on all three cilium-agent pods:

```
actual="dns drop tcp flow port-distribution icmp httpV2"
expectedValue="dns drop tcp flow port-distribution icmp httpV2:exemplars=true;labelsContext=..."
```

The `cilium-config` ConfigMap already contains the correct `httpV2` value with `labelsContext`. The agents loaded an older value at their last startup and have not been restarted since. The DaemonSet rollout triggered by this Helm upgrade will restart all agents and resolve the drift.

## Test plan

- [ ] Confirm Flux reconciles the HelmRelease and rolls out the Cilium DaemonSet
- [ ] `kubectl get pods -n kube-system -l k8s-app=cilium` — all agents Running and Ready
- [ ] Re-run `cilium connectivity test` — expect 0 failures (or only `to-fqdns` HTTP L7 if L7 proxy is not active for FQDN policies in this configuration)