### PR TITLE
revert(cilium): remove monitorAggregation: none — causes ring buffer overflow

### DIFF
--- a/infrastructure/controllers/cilium.yaml
+++ b/infrastructure/controllers/cilium.yaml
@@ -94,12 +94,6 @@ spec:
     # correctly and restores external DNS resolution.
     bpf:
       masquerade: false
-      # none: emit a flow event for every packet; required for cilium connectivity
-      # test's Hubble flow-validation steps (pod-to-service, pod-to-itself-via-service)
-      # to observe Service ClusterIP flows. At medium (default), per-connection events
-      # for ClusterIP traffic are aggregated away, leaving Hubble with zero matches.
-      # The performance cost is negligible on a three-node KinD cluster.
-      monitorAggregation: none
 
     # ── IPAM ─────────────────────────────────────────────────────────────────
     ipam:


### PR DESCRIPTION
## Summary

- Reverts the `bpf.monitorAggregation: none` setting introduced in PR #81
- Restores the default Cilium behaviour (`medium` aggregation)

## Why the revert

Setting `monitorAggregation: none` generates a flow event for every individual packet. The Hubble ring buffer (default 4096 entries) fills up between when a test action executes its curl and when the test framework queries Hubble for that flow. This pushed earlier events out of the buffer before they could be observed, causing **25 tests to fail** in `cilium connectivity test` — up from 5 at `medium`.

## Why the original failures are not fixable by aggregation

The 3 `pod-to-service` and `pod-to-itself-via-service` flow validation failures are a structural KinD + `kubeProxyReplacement: true` limitation:

Cilium's eBPF kube-proxy replacement performs Service → Pod DNAT inside the TC BPF program (`to-network` hook). All Hubble observation points are **downstream** of that hook. Hubble records the post-DNAT flow (to the backend pod IP); the connectivity test queries for the pre-DNAT flow (to the Service ClusterIP). No aggregation setting changes where in the kernel datapath the DNAT occurs.

## What was actually fixed

The `check-log-errors` test failure (agents running old `hubble-metrics` config without `labelsContext`) was fixed by the DaemonSet restart triggered in PR #81. That fix is preserved — this PR only removes the `monitorAggregation` line.

## Remaining known failures (structural KinD limitations)

| Test | Cause |
|---|---|
| `no-policies/pod-to-service` | BPF DNAT hides Service ClusterIP from Hubble |
| `allow-all-except-world/pod-to-service` | Same |
| `pod-to-itself-via-service` | Same |

For scripted connectivity test runs, add `--flow-validation warning` to demote these from failures to warnings.