### PR TITLE
fix: Kyverno extraArgs map format + Falco override syntax

### DIFF
--- a/infrastructure/controllers/falco.yaml
+++ b/infrastructure/controllers/falco.yaml
@@ -142,7 +142,8 @@ spec:
         # cilium-mount and cilium-sysctlfix from writable overlay layers at every pod
         # restart. These are expected privileged init-container operations, not attacks.
         - rule: Drop and execute new binary in container
-          append: true
+          override:
+            exceptions: append
           exceptions:
             - name: cilium_init_containers
               fields: [container.name]

--- a/infrastructure/controllers/kyverno.yaml
+++ b/infrastructure/controllers/kyverno.yaml
@@ -45,7 +45,7 @@ spec:
     admissionController:
       replicas: 1
       extraArgs:
-        - --v=1
+        v: "1"
       resources:
         requests:
           cpu: 100m
@@ -56,7 +56,7 @@ spec:
     backgroundController:
       replicas: 1
       extraArgs:
-        - --v=1
+        v: "1"
       resources:
         requests:
           cpu: 100m
@@ -67,7 +67,7 @@ spec:
     cleanupController:
       replicas: 1
       extraArgs:
-        - --v=1
+        v: "1"
       resources:
         requests:
           cpu: 100m
@@ -78,7 +78,7 @@ spec:
     reportsController:
       replicas: 1
       extraArgs:
-        - --v=1
+        v: "1"
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

Two regressions introduced by #84, caught during the post-merge cluster health check.

**Kyverno HelmRelease rollback** — `extraArgs` in the Kyverno 3.x chart is typed as a map (`{}`). PR #84 set it as a YAML sequence (`- --v=1`), causing Helm to warn `cannot overwrite table with non table` and roll back the release. Fixed by changing all four controllers to map syntax:
```yaml
extraArgs:
  v: "1"
```

**Falco deprecation warning** — Falco 0.37+ deprecated the top-level `append: true` key. Every agent restart logged `LOAD_DEPRECATED_ITEM: 'append' key is deprecated`. Fixed by using the new `override.exceptions: append` form.

## Test plan

- [x] `kubectl kustomize infrastructure/controllers/ --enable-helm` — clean
- [ ] After merge: confirm `flux get helmrelease kyverno -n flux-system` shows `Ready True`
- [ ] After merge: confirm Falco agents log no `LOAD_DEPRECATED_ITEM` warning for `cilium-exceptions.yaml`