### PR TITLE
fix: resolve ring health, cadvisor samples, kubescape scan, and grafana plugin errors

### DIFF
--- a/apps/base/grafana/helmrelease.yaml
+++ b/apps/base/grafana/helmrelease.yaml
@@ -64,8 +64,17 @@ spec:
     grafana.ini:
       analytics:
         check_for_updates: false
+        reporting_enabled: false
       plugins:
         allow_loading_unsigned_plugins: ""
+        # Grafana 12 preinstalls four "Drilldown" apps (exploretraces,
+        # metricsdrilldown, lokiexplore, pyroscope) from grafana.com on every
+        # pod start. KinD pods have no internet egress, so each attempt fails
+        # with a timeout and logs an error. Disable the background installer
+        # and the two other grafana.com callbacks that produce noise.
+        preinstall_disabled: "true"
+        angular_detection_enabled: "false"
+        public_key_retrieval_disabled: "true"
       dashboards:
         default_home_dashboard_path: /var/lib/grafana/dashboards/kubernetes/node-exporter-full.json
       log:

--- a/apps/base/loki/helmrelease.yaml
+++ b/apps/base/loki/helmrelease.yaml
@@ -38,6 +38,38 @@ spec:
         type: filesystem
       server:
         log_level: warn
+      # Switch all ring KV stores from memberlist to inmemory. In a single-replica
+      # deployment the memberlist ring loses its one member after Mac sleep (the
+      # heartbeat pauses for the length of the sleep, exceeding the 10-minute
+      # forget_period), leaving every component with 0 healthy instances. The
+      # inmemory store lives entirely in-process and never times out between
+      # the components that share the same binary.
+      ingester:
+        lifecycler:
+          ring:
+            kvstore:
+              store: inmemory
+            replication_factor: 1
+      distributor:
+        ring:
+          kvstore:
+            store: inmemory
+      compactor:
+        ring:
+          kvstore:
+            store: inmemory
+      query_scheduler:
+        ring:
+          kvstore:
+            store: inmemory
+      ruler:
+        ring:
+          kvstore:
+            store: inmemory
+      index_gateway:
+        ring:
+          kvstore:
+            store: inmemory
       schemaConfig:
         configs:
           - from: "2024-04-01"

--- a/apps/base/prometheus/helmrelease.yaml
+++ b/apps/base/prometheus/helmrelease.yaml
@@ -176,6 +176,12 @@ spec:
         # Metrics are lost on pod restart. Acceptable for a KinD dev cluster;
         # add a volumeClaimTemplate here for any persistent deployment.
         retention: 7d
+        # Accept cadvisor samples whose timestamps fall behind the TSDB head
+        # window after Mac sleep. The kubelet reports pre-sleep cgroup
+        # counters on wake, flooding Prometheus with "too old" samples.
+        # A 10-minute window covers any realistic sleep/wake gap.
+        tsdb:
+          outOfOrderTimeWindow: 10m0s
         resources:
           requests:
             cpu: 100m

--- a/apps/base/tempo/helmrelease.yaml
+++ b/apps/base/tempo/helmrelease.yaml
@@ -83,3 +83,13 @@ spec:
       # Retention: keep traces for 24 hours. Adjust upward once you understand
       # the storage growth rate for your trace volume.
       retention: 24h
+
+      # Switch the ingester ring from memberlist to inmemory. In a single-replica
+      # deployment the memberlist ring loses its member after Mac sleep, leaving
+      # the distributor with 0 live ingesters and dropping all incoming traces.
+      ingester:
+        lifecycler:
+          ring:
+            kvstore:
+              store: inmemory
+            replication_factor: 1

--- a/infrastructure/controllers/kubescape.yaml
+++ b/infrastructure/controllers/kubescape.yaml
@@ -58,6 +58,44 @@ spec:
       kubescapeOffline: enable
     configurations:
       prometheusAnnotations: disable
+  # The chart mounts an emptyDir at /home/nonroot/.kubescape/config.json via
+  # subPath: config.json. Kubernetes pre-creates the subPath as a directory
+  # inside the emptyDir, so the process sees a directory instead of a file and
+  # every scan fails. Replace the volume with a ConfigMap that has a
+  # config.json key so the mount produces a regular file.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: kubescape
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: kubescape
+              spec:
+                template:
+                  spec:
+                    volumes:
+                      - name: kubescape-volume
+                        $patch: replace
+                        configMap:
+                          name: kubescape-config
+                          items:
+                            - key: config.json
+                              path: config.json
+---
+# Provides the config.json file that the kubescape scanner reads at startup.
+# The chart generates an emptyDir for this volume; see the postRenderers patch
+# above for why a ConfigMap is used instead.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubescape-config
+  namespace: kubescape
+data:
+  config.json: "{}"
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## Summary

- **Loki + Tempo — inmemory ring KV stores:** Both tools use memberlist for ring coordination. After Mac sleep the KinD containers pause; the heartbeat stops longer than the 10-minute `forget_period`, the single instance is evicted from its own ring, and every operation fails with `at least 1 live replica required, could only find 0`. All Loki ring components (ingester, distributor, compactor, query_scheduler, ruler, index_gateway) and the Tempo ingester ring are switched from `memberlist` to `inmemory`. In a single-binary deployment the inmemory store is in-process and immune to sleep-induced timeouts.
- **Prometheus — `outOfOrderTimeWindow: 10m0s`:** On wake, the kubelet replays cadvisor cgroup counters with pre-sleep timestamps. All fall behind the TSDB head window and are dropped as "too old" (up to 4825 samples per scrape per node). A 10-minute out-of-order window accepts these samples without opening a large ingestion gap.
- **Kubescape — `config.json` ConfigMap:** The `kubescape-operator` chart mounts an `emptyDir` at `/home/nonroot/.kubescape/config.json` via `subPath: config.json`. Kubernetes pre-creates the subPath as a **directory** inside the emptyDir, so the scanner reads a directory instead of a file and every scheduled scan fails with `open config.json: is a directory`. A `postRenderers` kustomize patch replaces the emptyDir with a ConfigMap (`kubescape-config`) whose `config.json` key produces a regular file at that mount path.
- **Grafana — disable background plugin installer:** Grafana 12 preinstalls `exploretraces`, `metricsdrilldown`, `lokiexplore`, and `pyroscope` from `grafana.com` on every pod start. KinD pods have no internet egress; each attempt times out and logs an error. `preinstall_disabled`, `angular_detection_enabled=false`, and `public_key_retrieval_disabled=true` are set in `[plugins]`; usage reporting is also disabled.

## Test plan

- [ ] `flux get helmrelease loki -n flux-system` → Healthy; confirm no more `at least 1 healthy replica required` errors in Loki logs
- [ ] `flux get helmrelease tempo -n flux-system` → Healthy; confirm no more `pusher failed to consume trace data` errors in Tempo logs
- [ ] `flux get helmrelease kube-prometheus-stack -n flux-system` → Healthy; confirm cadvisor samples no longer appear as "too old" in Prometheus logs after next Mac sleep/wake
- [ ] `flux get helmrelease kubescape -n flux-system` → Healthy; confirm `kubectl get pod -n kubescape` shows kubescape pod Running; verify next scheduled scan completes without `is a directory` error
- [ ] `flux get helmrelease grafana -n flux-system` → Healthy; confirm Grafana logs show no `Failed to install plugin` errors after pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)