### PR TITLE
fix: add loki memberlist override and switch kubescape patch to RFC 6902

### DIFF
--- a/apps/base/loki/helmrelease.yaml
+++ b/apps/base/loki/helmrelease.yaml
@@ -38,6 +38,16 @@ spec:
         type: filesystem
       server:
         log_level: warn
+      # Override the chart-generated memberlist.join_members with an empty list.
+      # The chart always generates a join_members entry pointing to the headless
+      # memberlist Service, even with replicas=1. During a Helm upgrade the
+      # StatefulSet pod is replaced: the old pod terminates, the headless Service
+      # briefly has no ready endpoints, and Loki's memberlist fast-join fails with
+      # "no such host". An empty join_members removes this DNS dependency entirely;
+      # the memberlist subsystem is still initialized but it does not attempt to
+      # contact any remote nodes, so startup never blocks on DNS.
+      memberlist:
+        join_members: []
       # Switch all ring KV stores from memberlist to inmemory. In a single-replica
       # deployment the memberlist ring loses its one member after Mac sleep (the
       # heartbeat pauses for the length of the sleep, exceeding the 10-minute

--- a/infrastructure/controllers/kubescape.yaml
+++ b/infrastructure/controllers/kubescape.yaml
@@ -63,6 +63,14 @@ spec:
   # inside the emptyDir, so the process sees a directory instead of a file and
   # every scan fails. Replace the volume with a ConfigMap that has a
   # config.json key so the mount produces a regular file.
+  #
+  # The patch uses RFC 6902 format (op: replace) rather than a strategic merge
+  # patch because the SMP $patch: replace directive is silently ignored by the
+  # Kustomize version bundled in Flux — it merges configMap onto the existing
+  # volume entry and keeps the emptyDir field. The RFC 6902 op replaces the
+  # entire element at the specified path index with no ambiguity.
+  # Index 0 is stable for this chart: kubescape-volume is always the first
+  # volume in the chart-generated Deployment spec.
   postRenderers:
     - kustomize:
         patches:
@@ -70,21 +78,15 @@ spec:
               kind: Deployment
               name: kubescape
             patch: |
-              apiVersion: apps/v1
-              kind: Deployment
-              metadata:
-                name: kubescape
-              spec:
-                template:
-                  spec:
-                    volumes:
-                      - name: kubescape-volume
-                        $patch: replace
-                        configMap:
-                          name: kubescape-config
-                          items:
-                            - key: config.json
-                              path: config.json
+              - op: replace
+                path: /spec/template/spec/volumes/0
+                value:
+                  name: kubescape-volume
+                  configMap:
+                    name: kubescape-config
+                    items:
+                      - key: config.json
+                        path: config.json
 ---
 # Provides the config.json file that the kubescape scanner reads at startup.
 # The chart generates an emptyDir for this volume; see the postRenderers patch


### PR DESCRIPTION
## Summary

- **Loki `memberlist.join_members: []`** — the previous PR (#86) set all ring KV stores to `inmemory` but the chart still generated `memberlist.join_members: [observability-loki-memberlist.observability.svc.cluster.local]`. During the Helm upgrade, the old StatefulSet pod was replaced: the headless Service briefly had no ready endpoints, Loki's memberlist fast-join client failed with `no such host`, Loki crashed, the StatefulSet was marked `Failed`, and Flux rolled back. Setting `join_members: []` removes the DNS dependency at startup entirely. The memberlist subsystem initialises in-process and never contacts a remote node, so startup never blocks on DNS resolution.
- **Kubescape postRenderer → RFC 6902** — the previous PR used a Kustomize strategic merge patch with `$patch: replace` to swap `kubescape-volume` from `emptyDir` to `ConfigMap`. The directive was silently ignored by the Kustomize version bundled in Flux: it merged the `configMap` entry onto the existing volume without removing the `emptyDir` field. Switching to an RFC 6902 `op: replace` patch at `/spec/template/spec/volumes/0` replaces the entire volume element unambiguously. Index 0 is stable for this chart — `kubescape-volume` is always the first volume in the chart-generated Deployment.

## Test plan

- [ ] `flux get helmrelease loki -n flux-system` → `READY: True`; confirm Loki pod starts cleanly (no `failed to fast-join` crash in logs, only the harmless warn that is already suppressed)
- [ ] `flux get helmrelease grafana -n flux-system` → `READY: True` (unblocked once Loki is healthy)
- [ ] `flux get helmrelease promtail -n flux-system` → `READY: True` (same)
- [ ] `kubectl get deployment -n kubescape kubescape -o jsonpath='{.spec.template.spec.volumes[0]}'` → shows `configMap` not `emptyDir`
- [ ] Next scheduled kubescape scan completes without `open config.json: is a directory` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)