### PR TITLE
fix(trivy): mount emptyDir at /tmp in scan Job pods

### DIFF
--- a/infrastructure/controllers/trivy.yaml
+++ b/infrastructure/controllers/trivy.yaml
@@ -139,6 +139,18 @@ spec:
       capabilities:
         drop: [ALL]
 
+    # Mount a writable emptyDir at /tmp in every scan Job pod.
+    # Trivy creates temporary directories under /tmp during image scanning;
+    # if the path does not exist in the container image the scan aborts with
+    # "unable to create temporary directory: stat /tmp/trivy-N: no such file
+    # or directory". An emptyDir provides a fresh, writable /tmp on every pod.
+    scanJobPodTemplateVolumes:
+      - name: tmp
+        emptyDir: {}
+    scanJobPodTemplateVolumeMounts:
+      - name: tmp
+        mountPath: /tmp
+
     # Disable ServiceMonitor — use additionalScrapeConfigs instead.
     serviceMonitor:
       enabled: false


### PR DESCRIPTION
## Summary

- Adds `scanJobPodTemplateVolumes` and `scanJobPodTemplateVolumeMounts` to the Trivy Operator HelmRelease values
- Mounts a fresh `emptyDir` at `/tmp` in every ephemeral scan Job pod

## Problem

Trivy scan Job containers fail during alertmanager (and potentially other) container scans:

```
unable to create temporary directory: stat /tmp/trivy-11: no such file or directory
```

The Trivy scanner image does not include `/tmp` in its filesystem. When the operator launches a scan Job pod, `os.MkdirTemp` calls `os.Stat("/tmp")` first and fails because the directory does not exist.

## Fix

`scanJobPodTemplateVolumes` and `scanJobPodTemplateVolumeMounts` are top-level Trivy Operator chart values that inject extra volumes and volume mounts into every scan Job pod template. An `emptyDir` volume mounted at `/tmp` creates the directory fresh on each pod start, giving Trivy a writable scratch space without relaxing any security context settings.

## Test plan

- [ ] Merge and wait for Flux to reconcile the `trivy-operator` HelmRelease
- [ ] Confirm `kubectl get pods -n trivy-system` shows the operator restarted cleanly
- [ ] Watch the next scan Job: `kubectl get jobs -n trivy-system -w`
- [ ] Verify no `stat /tmp/trivy-N: no such file or directory` errors in scan container logs
- [ ] Confirm VulnerabilityReports are generated for all workloads: `kubectl get vulnerabilityreports -A`