### PR TITLE
fix(loki): remove compactor and query_scheduler ring configs invalid in Loki 3.6.x

### DIFF
--- a/apps/base/loki/helmrelease.yaml
+++ b/apps/base/loki/helmrelease.yaml
@@ -48,12 +48,16 @@ spec:
       # contact any remote nodes, so startup never blocks on DNS.
       memberlist:
         join_members: []
-      # Switch all ring KV stores from memberlist to inmemory. In a single-replica
-      # deployment the memberlist ring loses its one member after Mac sleep (the
-      # heartbeat pauses for the length of the sleep, exceeding the 10-minute
-      # forget_period), leaving every component with 0 healthy instances. The
-      # inmemory store lives entirely in-process and never times out between
-      # the components that share the same binary.
+      # Switch ring KV stores to inmemory for components that support it in
+      # Loki 3.6.x. In a single-replica deployment the memberlist ring loses its
+      # one member after Mac sleep (the heartbeat pauses for the length of the
+      # sleep, exceeding the 10-minute forget_period), leaving every component
+      # with 0 healthy instances. The inmemory store lives entirely in-process
+      # and never times out between the components that share the same binary.
+      #
+      # compactor.ring and query_scheduler.ring are intentionally omitted —
+      # those structs do not have a ring field in Loki 3.6.x and cause a
+      # config-parse error at startup ("field ring not found in type ...").
       ingester:
         lifecycler:
           ring:
@@ -61,14 +65,6 @@ spec:
               store: inmemory
             replication_factor: 1
       distributor:
-        ring:
-          kvstore:
-            store: inmemory
-      compactor:
-        ring:
-          kvstore:
-            store: inmemory
-      query_scheduler:
         ring:
           kvstore:
             store: inmemory


### PR DESCRIPTION
## Summary

- Removes `loki.compactor.ring` from the Loki HelmRelease values
- Removes `loki.query_scheduler.ring` from the Loki HelmRelease values
- Updates the comment to document which ring configs are valid vs. absent in Loki 3.6.x

## Root Cause

The Loki HelmRelease has been failing to upgrade after PR #87 with:

```
failed parsing config: /etc/loki/config/config.yaml: yaml: unmarshal errors:
  line 20: field ring not found in type compactor.Config
  line 59: field ring not found in type scheduler.Config
```

`compactor.Config` and `scheduler.Config` (query_scheduler) in Loki 3.6.x do not have a `ring` field. These were added in a later Loki release. The startup crash caused the StatefulSet to enter a Failed state, Flux rolled back, and after 4 attempts the HelmRelease reached `Stalled: RetriesExceeded`.

The remaining ring KV store overrides (ingester, distributor, ruler, index_gateway) are valid in Loki 3.6.x and are preserved to prevent sleep-induced ring-member eviction.

## Cascading Impact

Fixing this unblocks:
- `helmrelease/loki` → READY: True
- `helmrelease/grafana` → unblocked (depends on loki)
- `helmrelease/promtail` → unblocked (depends on loki)
- `kustomization/apps` → health check passes
- `kustomization/monitoring-rules` → unblocked (depends on apps)

## Test plan

- [ ] Merge and wait for Flux to reconcile `loki` HelmRelease
- [ ] Confirm `flux get helmrelease loki -n flux-system` shows READY: True
- [ ] Confirm no config-parse errors in `kubectl logs -n observability -l app.kubernetes.io/name=loki -c loki`
- [ ] Confirm `flux get all -A` shows all HelmReleases READY: True