### PR TITLE
fix(kubescape): remove obsolete config.json postRenderer

### DIFF
--- a/infrastructure/controllers/kubescape.yaml
+++ b/infrastructure/controllers/kubescape.yaml
@@ -58,46 +58,6 @@ spec:
       kubescapeOffline: enable
     configurations:
       prometheusAnnotations: disable
-  # The chart mounts an emptyDir at /home/nonroot/.kubescape/config.json via
-  # subPath: config.json. Kubernetes pre-creates the subPath as a directory
-  # inside the emptyDir, so the process sees a directory instead of a file and
-  # every scan fails. Replace the volume with a ConfigMap that has a
-  # config.json key so the mount produces a regular file.
-  #
-  # The patch uses RFC 6902 format (op: replace) rather than a strategic merge
-  # patch because the SMP $patch: replace directive is silently ignored by the
-  # Kustomize version bundled in Flux — it merges configMap onto the existing
-  # volume entry and keeps the emptyDir field. The RFC 6902 op replaces the
-  # entire element at the specified path index with no ambiguity.
-  # Index 0 is stable for this chart: kubescape-volume is always the first
-  # volume in the chart-generated Deployment spec.
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: kubescape
-            patch: |
-              - op: replace
-                path: /spec/template/spec/volumes/0
-                value:
-                  name: kubescape-volume
-                  configMap:
-                    name: kubescape-config
-                    items:
-                      - key: config.json
-                        path: config.json
----
-# Provides the config.json file that the kubescape scanner reads at startup.
-# The chart generates an emptyDir for this volume; see the postRenderers patch
-# above for why a ConfigMap is used instead.
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubescape-config
-  namespace: kubescape
-data:
-  config.json: "{}"
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## Summary

- Removes the `postRenderers` block and the `kubescape-config` ConfigMap from the Kubescape HelmRelease

## Root Cause

The postRenderer was added to work around a Kubernetes subPath/emptyDir behavior: when the chart mounted `kubescape-volume` (emptyDir) at `mountPath: /home/nonroot/.kubescape/config.json` with `subPath: config.json`, Kubernetes pre-created the subPath as a **directory** inside the emptyDir. The process then received a directory at a path it expected to be a file, causing every scan to fail.

The fix replaced the emptyDir with a ConfigMap so the subPath resolved to a real file.

## Why the Fix is Now Obsolete

In kubescape-operator 1.40.x the chart changed the volumeMount:

```
# OLD (mountPath = a file path)
mountPath: /home/nonroot/.kubescape/config.json
subPath: config.json

# NEW (mountPath = a directory path)
mountPath: /home/nonroot/.kubescape
subPath: config.json
```

With the new `mountPath`, the emptyDir subPath correctly produces a **writable directory** at `/home/nonroot/.kubescape`, which is what the process expects. The ConfigMap replacement is no longer needed.

## Why This Also Fixes the Fresh-Install Crash

The postRenderer used `op: replace` at path `/spec/template/spec/volumes/0`. In 1.40.2 the Deployment's volume list is:

| Index | Name |
|-------|------|
| 0 | `cloud-secret` |
| 1 | `ks-cloud-config` |
| 2 | `host-scanner-definition` |
| 3 | `kubescape-volume` ← target |

Replacing index 0 put a second `kubescape-volume` into the list while the original at index 3 remained, causing Kubernetes server-side apply to reject the Deployment with:

> `.spec.template.spec.volumes: duplicate entries for key [name="kubescape-volume"]`

Removing the postRenderer entirely eliminates the duplicate and no longer requires tracking the volume index across chart upgrades.

## Test Plan

- [ ] Merge and wait for Flux to reconcile `helmrelease/kubescape`
- [ ] Confirm `flux get helmrelease kubescape -n flux-system` shows READY: True
- [ ] Confirm `kubectl get pods -n kubescape` shows all pods Running
- [ ] Confirm kubescape scans complete: `kubectl get configurationscansummaries -A`