### PR TITLE
fix(kubescape): add remediateLastFailure to install remediation

### DIFF
--- a/infrastructure/controllers/kubescape.yaml
+++ b/infrastructure/controllers/kubescape.yaml
@@ -25,6 +25,7 @@ spec:
     crds: CreateReplace
     remediation:
       retries: 3
+      remediateLastFailure: true
   upgrade:
     crds: CreateReplace
     cleanupOnFail: true


### PR DESCRIPTION
## Summary

- Adds `remediateLastFailure: true` to the `install.remediation` block in the Kubescape HelmRelease.
- The upgrade remediation already had this flag; the install block was missing it.
- Without it, Flux leaves the release in a failed state after exhausting install retries rather than rolling back, requiring manual `flux suspend/resume` on fresh cluster bootstraps.

## Test plan

- [ ] Confirm `flux get helmrelease kubescape -n flux-system` shows `Ready: True` after a fresh cluster bootstrap.
- [ ] Confirm that if an install fails, Flux rolls back and retries rather than entering `RetriesExceeded`.