### PR TITLE
fix(loki): raise per_stream_rate_limit_burst to 20 MB for post-sleep bursts

### DIFF
--- a/apps/base/loki/helmrelease.yaml
+++ b/apps/base/loki/helmrelease.yaml
@@ -87,6 +87,12 @@ spec:
               period: 24h
       limits_config:
         retention_period: 168h   # 7 days
+        # After a Mac sleep the host clock pauses; when the machine wakes, all
+        # log shippers flush their buffered output at once. The default
+        # per_stream_rate_limit_burst (default ~4 MB) is too small to absorb
+        # this burst and Loki silently drops the overflow with HTTP 429.
+        # 20 MB provides enough headroom for a typical multi-minute sleep.
+        per_stream_rate_limit_burst: 20MB
 
     singleBinary:
       replicas: 1


### PR DESCRIPTION
## Summary

- Adds `per_stream_rate_limit_burst: 20MB` to `loki.limits_config` in the Loki HelmRelease.
- After a Mac sleep, the host clock pauses for the duration of the sleep. When the machine wakes, Promtail, Falcosidekick, and all other log shippers flush their buffered output simultaneously. The default burst capacity (~4 MB) is too small to absorb this, and Loki silently discards the overflow with HTTP 429 status codes — no visible indication appears in Grafana.
- 20 MB provides sufficient headroom to absorb a typical multi-minute sleep burst without dropping entries.

## Test plan

- [ ] Confirm Loki reconciles successfully: `flux get helmrelease loki -n flux-system`.
- [ ] Put the Mac to sleep for several minutes, wake it, then check for gaps in Grafana log explorer — there should be no silent drop.
- [ ] Confirm no `429` responses in Promtail logs: `kubectl logs -n observability -l app.kubernetes.io/name=promtail --tail=20 | grep 429`.