### PR TITLE
feat(monitoring): add PrometheusRule alert for Loki ingestion rate limit hits

### DIFF
--- a/apps/base/monitoring-rules/rules.yaml
+++ b/apps/base/monitoring-rules/rules.yaml
@@ -137,6 +137,32 @@ spec:
               Query Loki for details:
               {app="falcosidekick"} | json | priority=~"Critical|Emergency"
 
+    # ── Loki ingestion rate limiting ──────────────────────────────────────────
+    - name: loki.ingestion
+      interval: 1m
+      rules:
+        - alert: LokiIngestionRateLimitHit
+          # Counts push requests rejected by Loki's per-stream rate limiter.
+          # A non-zero rate means log entries are being silently dropped.
+          # Common cause: post-sleep burst from Promtail and Falcosidekick
+          # flushing buffered output simultaneously.
+          expr: |
+            increase(
+              loki_request_duration_seconds_count{
+                route="/loki/api/v1/push",
+                status_code="429"
+              }[5m]
+            ) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Loki is dropping log entries due to per-stream rate limit"
+            description: >-
+              {{ $value }} push requests returned HTTP 429 in the last 5 minutes.
+              Log entries are being silently discarded. Consider raising
+              per_stream_rate_limit_burst in loki.limits_config.
+
     # ── Security: Kyverno policy enforcement ──────────────────────────────────
     - name: security.kyverno
       interval: 5m


### PR DESCRIPTION
## Summary

- Adds a `loki.ingestion` group to the cluster's PrometheusRule with a `LokiIngestionRateLimitHit` alert.
- Fires immediately when any push to `/loki/api/v1/push` returns HTTP 429, which indicates Loki is silently dropping log entries due to per-stream rate limiting.
- Without this alert, dropped entries are invisible in Grafana — there is no error displayed, only a gap in the log stream.
- Complements PR #94 (raising `per_stream_rate_limit_burst`) by making future 429s visible if they still occur.

## Test plan

- [ ] Confirm PrometheusRule is picked up: `kubectl get prometheusrule -n observability flux-cluster-alerts -o yaml | grep loki.ingestion`.
- [ ] Confirm the alert appears in Prometheus Rules UI at `http://prometheus.local:8080/rules`.
- [ ] Simulate a 429 (if feasible) or verify the alert expression evaluates cleanly: `kubectl exec -n observability prometheus-observability-kube-prometh-prometheus-0 -- promtool query instant http://localhost:9090 'increase(loki_request_duration_seconds_count{route="/loki/api/v1/push",status_code="429"}[5m])'`.