### PR TITLE
fix(grafana): redirect grafana.com to localhost to prevent startup timeouts

### DIFF
--- a/apps/base/grafana/helmrelease.yaml
+++ b/apps/base/grafana/helmrelease.yaml
@@ -65,6 +65,14 @@ spec:
       analytics:
         check_for_updates: false
         reporting_enabled: false
+      # Redirect grafana.com outbound traffic to localhost. In a no-egress KinD
+      # environment grafana.com is unreachable, so the angular pattern updater,
+      # plugin installer, and public-key retriever all time out at startup and
+      # log errors. Setting grafana_com.url to an unrouteable loopback address
+      # causes these HTTP requests to fail immediately (connection refused) rather
+      # than waiting for a 30-second timeout, removing the slow startup noise.
+      grafana_com:
+        url: "http://127.0.0.1:1"
       plugins:
         allow_loading_unsigned_plugins: ""
         # Grafana 12 preinstalls four "Drilldown" apps (exploretraces,


### PR DESCRIPTION
## Summary

- Adds `grafana_com.url: "http://127.0.0.1:1"` to `grafana.ini` in the Grafana HelmRelease.
- In Grafana 12.x, the dynamic angular-pattern updater (`plugin.angulardetectorsprovider.dynamic`) contacts `grafana.com/api/plugins/angular_patterns` at startup regardless of `angular_detection_enabled: false`. In a no-egress KinD environment this produces a 30-second HTTP timeout logged as `level=error`.
- Pointing `grafana_com.url` at an unrouteable loopback address (`127.0.0.1:1`) causes all outbound grafana.com requests (angular patterns, Drilldown plugin installer, public-key retriever) to fail instantly with connection refused instead of waiting out a timeout.
- The existing `preinstall_disabled: "true"`, `angular_detection_enabled: "false"`, and `public_key_retrieval_disabled: "true"` settings remain in place as belt-and-suspenders.

## Test plan

- [ ] Confirm Grafana reconciles: `flux get helmrelease grafana -n flux-system`.
- [ ] Confirm Grafana is accessible: `curl -s -o /dev/null -w "%{http_code}" -H "Host: grafana.local" http://localhost:8080/` → 302.
- [ ] Confirm no `plugin.angulardetectorsprovider.dynamic` timeout errors in Grafana logs after restart: `kubectl logs -n observability -l app.kubernetes.io/name=grafana --tail=30 | grep -i "angular\|timeout"`.