### PR TITLE
fix(otel): pin image digest and migrate telemetry resource to new attributes format

### DIFF
--- a/apps/base/opentelemetry/helmrelease.yaml
+++ b/apps/base/opentelemetry/helmrelease.yaml
@@ -50,6 +50,8 @@ spec:
 
     image:
       repository: otel/opentelemetry-collector-contrib
+      tag: "0.153.0"
+      digest: "sha256:93aad750175cbf1a973ae1c5886c3371f4d800f61be25cdd26870b8441ffe9fa"
 
     podLabels:
       sidecar.istio.io/inject: "false"
@@ -167,3 +169,24 @@ spec:
         telemetry:
           logs:
             level: warn
+          # The chart 0.158.x generates the legacy service.telemetry.resource
+          # inline map format (host.name: ..., k8s.namespace.name: ...) from its
+          # default values. OTel Collector 0.153.0 warns about this format and
+          # prefers resource.attributes (array). Adding the attributes array here
+          # causes the collector to use the new format; when attributes is non-empty
+          # the collector suppresses the legacy-format warning and ignores the
+          # chart-injected inline map keys.
+          resource:
+            attributes:
+              - name: host.name
+                value: ${env:OTEL_K8S_NODE_NAME}
+              - name: k8s.namespace.name
+                value: ${env:OTEL_K8S_NAMESPACE}
+              - name: k8s.node.ip
+                value: ${env:OTEL_K8S_NODE_IP}
+              - name: k8s.node.name
+                value: ${env:OTEL_K8S_NODE_NAME}
+              - name: k8s.pod.ip
+                value: ${env:OTEL_K8S_POD_IP}
+              - name: k8s.pod.name
+                value: ${env:OTEL_K8S_POD_NAME}


### PR DESCRIPTION
## Summary

Two fixes in one PR for the OTel Collector HelmRelease (`apps/base/opentelemetry/helmrelease.yaml`).

**Task 5 — Migrate `service.telemetry.resource` to new `attributes` format**

OTel Collector 0.153.0 logs the following warning at startup:
```
Using legacy service.telemetry.resource inline map format; prefer
service.telemetry.resource.attributes (array of maps with `name` and `value` keys)
```
The chart 0.158.1 generates the old inline map format (`host.name: …`, `k8s.namespace.name: …`) from its default values. Adding `resource.attributes` in our HelmRelease values tells the collector to use the new format — when `attributes` is non-empty, the collector bypasses the legacy code path and suppresses the warning. The chart-injected inline keys are retained in the merged ConfigMap but ignored by the collector.

**Task 8 — Pin image tag and digest**

Adds `tag: "0.153.0"` and `digest: "sha256:93aad750…"` to the image block. Without an explicit tag the chart uses its `appVersion`, and without a digest Kubernetes may pull a different binary if the tag is mutated in the registry. The digest is taken from the currently running pod (`kubectl get pod … -o jsonpath='{.status.containerStatuses[0].imageID}'`).

## Test plan

- [ ] Confirm HelmRelease reconciles: `flux get helmrelease opentelemetry-collector -n flux-system`.
- [ ] Confirm OTel collector pod image matches pinned digest: `kubectl get pod -n observability -l app.kubernetes.io/name=opentelemetry-collector -o jsonpath='{.items[0].status.containerStatuses[0].imageID}'`.
- [ ] Confirm no `legacy service.telemetry.resource` warning in OTel logs: `kubectl logs -n observability -l app.kubernetes.io/name=opentelemetry-collector --tail=30 | grep -i "legacy\|resource"`.