### PR TITLE
fix(envoy-gateway): switch to explicit namespace watch to stop Service-not-found loop

### DIFF
--- a/infrastructure/controllers/envoy-gateway.yaml
+++ b/infrastructure/controllers/envoy-gateway.yaml
@@ -74,6 +74,24 @@ spec:
         logging:
           level:
             default: warn
+        provider:
+          kubernetes:
+            # Restrict the controller's informer cache to only these namespaces.
+            # Without an explicit watch.namespaces list the cache defaults to
+            # cluster-scoped, but Envoy Gateway 1.8.x has a known behaviour where
+            # its Service informer fails to populate for namespaces that contain
+            # only HTTPRoute backends (not Gateway API control-plane objects). The
+            # controller logs a continuous "Service not found" error loop for
+            # observability-grafana and observability-kube-prometh-prometheus even
+            # though routing works correctly. Switching to explicit namespace-scoped
+            # watch eliminates the error loop because the cache is initialised for
+            # all listed namespaces unconditionally at startup.
+            watch:
+              type: Namespaces
+              namespaces:
+                - envoy-gateway-system
+                - envoy-ingress
+                - observability
 ---
 # ── envoy-gateway-system (controller) ────────────────────────────────────────
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## Summary

- Adds `provider.kubernetes.watch.type: Namespaces` with `[envoy-gateway-system, envoy-ingress, observability]` to the Envoy Gateway config.
- Envoy Gateway 1.8.1 logs a continuous `failed to get Service … not found` error loop for `observability-grafana` and `observability-kube-prometh-prometheus` despite both services existing and routing working (confirmed: `curl -H "Host: grafana.local" http://localhost:8080/` → 302, same for Prometheus).
- **Root cause**: with an implicit cluster-scoped watch, the controller's Service informer cache is not reliably populated for namespaces that contain only HTTPRoute backends (not Gateway CRs). The controller re-reconciles on every unrelated watch event, failing the Service cache lookup each time at ~1–4 second intervals.
- **Fix**: switching to explicit namespace-scoped watch forces the informer to be initialised for all listed namespaces unconditionally at startup, ensuring Service lookups succeed immediately.
- **Trade-off**: HTTPRoutes in any namespace not listed here will not be reconciled. The current cluster only uses `observability` for HTTPRoutes; adding any other namespace later requires updating this list.

## Test plan

- [ ] Confirm `flux get helmrelease envoy-gateway -n flux-system` shows `Ready: True` after reconcile.
- [ ] Confirm `kubectl logs -n envoy-gateway-system deployment/envoy-gateway --tail=30 | grep "failed to get Service"` returns no output after Envoy Gateway restarts.
- [ ] Confirm routing still works: `curl -s -o /dev/null -w "%{http_code}" -H "Host: grafana.local" http://localhost:8080/` → 302.
- [ ] Confirm routing still works: `curl -s -o /dev/null -w "%{http_code}" -H "Host: prometheus.local" http://localhost:8080/` → 302.