### PR TITLE
fix(etcd): tune KinD etcd compaction for high CRD count and add crd-count guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ BOOTSTRAP_IMAGES := \
 .PHONY: help \
         bootstrap destroy branch \
         pull-images load-images cache-running \
-        check-tools status watch validate \
+        check-tools status watch validate check-crd-count \
         sops-setup sops-load-key \
         test-policies test-falco test-cluster test-kubescape \
         test-iperf3 test-iperf3-circuit-breaker test-iperf3-overflow
@@ -168,6 +168,16 @@ sops-load-key: ## Load Age private key into cluster as sops-age secret (run afte
 
 status: ## Show Flux reconciliation state across all namespaces
 	flux get all -A
+
+check-crd-count: ## Warn if installed CRD count approaches the etcd slow-list threshold (>150)
+	@count=$$(kubectl get crds --no-headers 2>/dev/null | wc -l | tr -d ' '); \
+	printf "Installed CRDs: %s\n" "$$count"; \
+	if [ "$$count" -gt 150 ]; then \
+	  printf "WARNING: CRD count %s exceeds 150.\n" "$$count"; \
+	  printf "High CRD counts slow etcd LIST responses and cause watch-mark-send-over-slow-network\n"; \
+	  printf "warnings. Review Helm chart CRD installations; consider disabling unused capabilities.\n"; \
+	  exit 1; \
+	fi
 
 watch: ## Watch Flux reconcile every 6 s (Ctrl-C to stop)
 	watch -n 6 "flux get all -A"

--- a/scripts/setup-fluxcd-gitops-kind-multinode.sh
+++ b/scripts/setup-fluxcd-gitops-kind-multinode.sh
@@ -118,6 +118,25 @@ networking:
 nodes:
   - role: control-plane
     image: kindest/node:${K8S_VER}
+    # Tune the single-instance etcd embedded in the KinD control-plane.
+    # Default quota-backend-bytes is 2 GiB; this stack installs 120+ CRDs whose
+    # validation schemas are large — raising the quota to 8 GiB prevents the
+    # "mvcc: database space exceeded" alarm that forces a defrag before any write.
+    # auto-compaction keeps the MVCC history bounded. Without compaction, the
+    # revision count grows indefinitely after every Flux reconcile, causing
+    # watch-mark-send-over-slow-network warnings and slow LIST responses. A
+    # 1-hour periodic compaction keeps the live revisions in a small window that
+    # etcd can serve quickly.
+    kubeadmConfigPatches:
+      - |
+        apiVersion: kubeadm.k8s.io/v1beta3
+        kind: ClusterConfiguration
+        etcd:
+          local:
+            extraArgs:
+              quota-backend-bytes: "8589934592"
+              auto-compaction-retention: "1"
+              auto-compaction-mode: periodic
     # extraPortMappings forward localhost ports into the KinD node container.
     #
     # Port 8888 (not a NodePort) is used instead of 30080 because Cilium's kube-proxy


### PR DESCRIPTION
## Summary

Two changes to address the etcd slowdown observed with 123+ CRDs installed in the cluster.

**`scripts/setup-fluxcd-gitops-kind-multinode.sh` — etcd tuning via `kubeadmConfigPatches`**

Adds `kubeadmConfigPatches` to the control-plane node with three etcd `extraArgs`:

| Setting | Value | Reason |
|---|---|---|
| `quota-backend-bytes` | `8589934592` (8 GiB) | Stack installs 120+ CRDs with large OpenAPI v3 validation schemas; default 2 GiB can trigger `mvcc: database space exceeded`, blocking all writes until `etcdctl defrag` is run |
| `auto-compaction-mode` | `periodic` | Enables MVCC history compaction |
| `auto-compaction-retention` | `1` | Compacts revisions older than 1 hour; without this, every Flux reconcile increments the global revision, growing the keyspace indefinitely and causing `watch-mark-send-over-slow-network` warnings and slow LIST responses |

These settings take effect on the next `make destroy && make bootstrap`.

**`Makefile` — `make check-crd-count` target**

Counts installed CRDs with `kubectl get crds` and exits non-zero if the count exceeds 150, printing a human-readable warning. Useful to run after adding new Helm releases to detect CRD creep before it becomes a performance problem. Not wired into CI (requires a live cluster).

## Test plan

- [ ] After `make destroy && make bootstrap`, confirm etcd flags are applied: `kubectl exec -n kube-system etcd-flux-kind-control-plane -- etcd --help 2>&1 | grep compaction` (or check pod args).
- [ ] Confirm `make check-crd-count` passes (exits 0) with the current 123 CRDs.
- [ ] After a long reconcile session, confirm etcd database size stays bounded: `kubectl exec -n kube-system etcd-flux-kind-control-plane -- etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/peer.crt --key=/etc/kubernetes/pki/etcd/peer.key endpoint status --write-out=table`.