### PR TITLE
fix(envoy-gateway): pre-create observability namespace in infrastructure layer

### DIFF
--- a/infrastructure/controllers/envoy-gateway.yaml
+++ b/infrastructure/controllers/envoy-gateway.yaml
@@ -19,6 +19,19 @@ metadata:
   labels:
     istio-injection: disabled
 ---
+# observability is pre-created here at the infrastructure layer so it exists
+# when Envoy Gateway installs. With watch.namespaces configured below, the
+# Envoy Gateway chart creates a Role and RoleBinding in every watched namespace
+# during Helm install. The observability namespace is normally created by
+# kube-prometheus-stack (apps layer), which runs after infrastructure, so
+# without this pre-creation the Helm install fails with "namespaces not found".
+# kube-prometheus-stack applies its own labels via SSA with a separate field
+# manager; Kubernetes merges both field managers cleanly.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+---
 # Envoy Gateway installs its own CRDs (EnvoyProxy, GatewayClass, BackendTrafficPolicy,
 # etc.) via the Helm chart. The Gateway API CRDs (Gateway, HTTPRoute, GatewayClass) are
 # installed by the setup script (step 4) before Flux bootstrap, so they exist when this


### PR DESCRIPTION
## Summary

Followup to #98 which introduced `watch.namespaces: [envoy-gateway-system, envoy-ingress, observability]`.

When `watch.namespaces` is configured, the Envoy Gateway Helm chart creates a `Role` and `RoleBinding` in **each watched namespace** during install, giving the controller RBAC to watch Gateway API resources there. On a fresh cluster, the `observability` namespace is created by `kube-prometheus-stack` (apps layer), which runs **after** all infrastructure HelmReleases. This ordering caused the Envoy Gateway Helm install to fail immediately with:

```
server-side apply failed for object observability/…-envoy-gateway-role Kind=Role: namespaces "observability" not found
```

The release then entered a terminal `Stalled` state and required manual `flux suspend` + status patch to recover.

**Fix**: pre-create a bare `observability` Namespace object at the infrastructure layer so it exists before any HelmRelease runs. `kube-prometheus-stack` later adds its own labels via SSA with a separate field manager; Kubernetes merges both field managers cleanly.

## Test plan

- [ ] `make destroy && make bootstrap` — confirm Envoy Gateway installs cleanly on first attempt (no `namespaces not found` error).
- [ ] Confirm `flux get helmrelease envoy-gateway -n flux-system` shows `Ready: True`.
- [ ] Confirm `kubectl get ns observability` exists with labels from kube-prometheus-stack after apps reconcile.
- [ ] Confirm `curl -s -o /dev/null -w "%{http_code}" -H "Host: grafana.local" http://localhost:8080/` → 302.