### PR TITLE
fix(otel): remove resource.attributes — incompatible with chart inline defaults

### DIFF
--- a/apps/base/opentelemetry/helmrelease.yaml
+++ b/apps/base/opentelemetry/helmrelease.yaml
@@ -169,24 +169,10 @@ spec:
         telemetry:
           logs:
             level: warn
-          # The chart 0.158.x generates the legacy service.telemetry.resource
-          # inline map format (host.name: ..., k8s.namespace.name: ...) from its
-          # default values. OTel Collector 0.153.0 warns about this format and
-          # prefers resource.attributes (array). Adding the attributes array here
-          # causes the collector to use the new format; when attributes is non-empty
-          # the collector suppresses the legacy-format warning and ignores the
-          # chart-injected inline map keys.
-          resource:
-            attributes:
-              - name: host.name
-                value: ${env:OTEL_K8S_NODE_NAME}
-              - name: k8s.namespace.name
-                value: ${env:OTEL_K8S_NAMESPACE}
-              - name: k8s.node.ip
-                value: ${env:OTEL_K8S_NODE_IP}
-              - name: k8s.node.name
-                value: ${env:OTEL_K8S_NODE_NAME}
-              - name: k8s.pod.ip
-                value: ${env:OTEL_K8S_POD_IP}
-              - name: k8s.pod.name
-                value: ${env:OTEL_K8S_POD_NAME}
+          # resource.attributes (new format) cannot coexist with the chart's
+          # default inline map keys (host.name, k8s.namespace.name, ...) because
+          # OTel Collector 0.153.0 rejects the combination with a validation error.
+          # Helm deep-merge cannot remove chart-default keys, so we cannot cleanly
+          # switch to the new format without a postRenderer. The legacy inline map
+          # triggers a deprecation WARNING (not an error) and is functionally
+          # correct — accept it until the chart updates its defaults.


### PR DESCRIPTION
## Summary

Reverts the `resource.attributes` addition from #97.

OTel Collector 0.153.0 throws a **validation error** (not just a warning) when `resource.attributes` and any legacy inline resource key appear together in the same `resource` block:

```
invalid configuration: service::telemetry::resource: resource::attributes
cannot be used together with legacy inline resource attributes
stream closed: EOF for observability/observability-opentelemetry-collector-…
```

The root cause: the chart 0.158.1 injects the legacy inline keys (`host.name`, `k8s.namespace.name`, `k8s.node.ip`, `k8s.node.name`, `k8s.pod.ip`, `k8s.pod.name`) from its own `values.yaml`. Helm deep-merge adds our `attributes` array **alongside** those keys rather than replacing them, so both formats land in the rendered ConfigMap and the collector refuses to start.

The only way to switch to the new format without a postRenderer would be to override all six legacy keys to empty strings in our values — but OTel Collector still sees them as present (even with empty string values) and throws the same error.

Removing `resource.attributes` restores the legacy-only format. The deprecation `WARNING` (`Using legacy service.telemetry.resource inline map format`) is cosmetic and does not affect collector operation. The image digest pin added in #97 (`tag: "0.153.0"`, `digest: "sha256:93aad…"`) is kept.

## Test plan

- [ ] Confirm HelmRelease reconciles: `flux get helmrelease opentelemetry-collector -n flux-system`.
- [ ] Confirm collector pod starts cleanly: `kubectl logs -n observability -l app.kubernetes.io/name=opentelemetry-collector --tail=20 | grep -i "error\|invalid"` → no output.
- [ ] Confirm traces flow to Tempo (Grafana Explore → Tempo datasource).