### PR TITLE
fix(netpol): add default-deny to boinc and openebs namespaces

### DIFF
--- a/apps/base/boinc/netpol.yaml
+++ b/apps/base/boinc/netpol.yaml
@@ -1,4 +1,18 @@
 ---
+# BOINC is a pure compute client — it initiates connections to project servers
+# but never listens for inbound connections. Default-deny covers all pods in this
+# namespace; the egress policy below then allows only what BOINC actually needs.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: boinc
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/infrastructure/controllers/openebs.yaml
+++ b/infrastructure/controllers/openebs.yaml
@@ -61,3 +61,51 @@ spec:
         isDefaultClass: true
       analytics:
         enabled: false
+---
+# ── openebs namespace ─────────────────────────────────────────────────────────
+# localpv-provisioner is a storage controller that watches PVC/PV objects via the
+# Kubernetes API and bind-mounts host paths. It has no network server component
+# and needs no ingress. Egress is limited to DNS and the API server.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openebs
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: openebs
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-apiserver-egress
+  namespace: openebs
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 6443


### PR DESCRIPTION
## Summary

- **boinc**: the existing `boinc-egress` policy only declared `policyTypes: [Egress]`, which leaves Ingress uncontrolled — any pod in the cluster could initiate connections to BOINC pods. BOINC is a pure compute client with no server component; a `default-deny` closes the gap with zero ingress exceptions required.
- **openebs**: the `localpv-provisioner` namespace had no NetworkPolicies at all. As a storage controller that only needs DNS resolution and Kubernetes API access to manage PV/PVC objects, it now gets `default-deny` plus the two minimal egress rules.

## Test plan

- [ ] Merge and run `flux reconcile kustomization infrastructure-controllers --with-source`
- [ ] Confirm localpv-provisioner remains `Running` and PVC provisioning still works: `kubectl get pods -n openebs`
- [ ] Confirm BOINC DaemonSet remains `Running` and connects to project servers: `kubectl logs -n boinc -l app=boinc --tail=20`
- [ ] Confirm no new `NetworkPolicy` blocks appear in Cilium Hubble for openebs or boinc legitimate traffic