### PR TITLE
docs: version refresh and full documentation audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,37 +191,40 @@ flux-system (GitRepository)
 
 ## Deployed Components
 
-| Component | Chart / Source | Version | Namespace | Notes |
-|---|---|---|---|---|
-| Cilium CNI | cilium/cilium | 1.19.4 | kube-system | |
-| Hubble Relay | (bundled with Cilium) | 1.19.4 | kube-system | |
-| Hubble UI | (bundled with Cilium) | 0.13.1 | kube-system | Disabled by default; enable via `hubble.ui.enabled: true` in `cilium.yaml` |
-| cert-manager | cert-manager/cert-manager | v1.20.2 | cert-manager | |
-| OpenEBS localpv | openebs/openebs | 4.5.0 | openebs | |
-| istio-base | istio/base | 1.30.1 | istio-system | |
-| istiod | istio/istiod | 1.30.1 | istio-system | |
-| Gateway API CRDs | kubernetes-sigs/gateway-api | v1.2.1 | (cluster-scoped) | |
-| Envoy Gateway | envoy-gateway/gateway | 1.8.1 | envoy-gateway-system | |
-| Envoy Gateway data-plane | gatewayClassName: eg | 1.8.1 | envoy-ingress | Auto-provisioned by Envoy Gateway controller; uses Gateway API (HTTPRoute) |
-| Contour | projectcontour/contour | 0.6.0 (app v1.33.5) | contour | HTTPProxy CRD control plane; streams xDS to its own Envoy DaemonSet on gRPC port 8001 |
-| Contour Envoy data-plane | (bundled with Contour chart) | 0.6.0 (app v1.33.5) | contour | DaemonSet data plane; separate from Envoy Gateway auto-provisioned pods |
-| Metrics Server | metrics-server/metrics-server | 3.13.1 | metrics-server | Powers `kubectl top` and HPA; `--kubelet-insecure-tls` required for KinD |
-| kube-prometheus-stack | prometheus-community/kube-prometheus-stack | 86.2.2 | observability | |
-| Grafana | grafana/grafana | 10.5.15 | observability | |
-| Loki | grafana/loki | 7.0.0 | observability | |
-| Promtail | grafana/promtail | 6.17.1 | observability | |
-| Grafana Tempo | grafana/tempo | 1.24.4 | observability | Single-binary mode; trace backend for the OTel pipeline |
-| OpenTelemetry Collector | open-telemetry/opentelemetry-collector | 0.158.1 | observability | Contrib distribution; OTLP ingress → Tempo export; Istio sidecar disabled |
-| Tetragon | cilium/tetragon | 1.7.0 | tetragon | |
-| Kyverno | kyverno/kyverno | 3.8.1 | kyverno | |
-| Kubescape | kubescape/kubescape-operator | 1.40.2 | kubescape | NSA + MITRE continuous scan; vulnerability scan disabled for KinD |
-| Falco + Falcosidekick | falcosecurity/falco | 9.1.0 | falco | |
-| Trivy Operator | aquasecurity/trivy-operator | 0.33.1 | trivy-system | Image CVE scanning — VulnerabilityReport CRDs + Prometheus metrics; `ignoreUnfixed: true` |
-| demo (httpbin) | kennethreitz/httpbin | @sha256 digest pin | demo | No versioned tags published; pinned by digest |
-| iperf3 server | networkstatic/iperf3 | multiarch | iperf3 | TCP bandwidth measurement; BackendTrafficPolicy enforces maxConnections: 10 circuit-breaker |
-| BOINC | boinc/client | arm64v8 | boinc | Voluntary compute — Rosetta@Home + Einstein@Home; capped at 1 CPU core for thermal management |
-| Renovate | renovatebot/github-action | (GitHub Actions workflow) | — | Automated dependency PRs for Helm charts, images, GitHub Actions, and CI tool pins |
-| Gitleaks | gitleaks/gitleaks | (CI workflow pin) | — | Secret scanning on every PR — detects accidentally committed credentials before merge |
+The "Chart Version" column is the Helm chart release version. The "App Version" column is the version of the software the chart deploys — the number that appears in `docker ps` or the application's own `--version` flag. These two numbers often differ.
+
+| Component | Chart / Source | Chart Version | App Version | Namespace | Notes |
+|---|---|---|---|---|---|
+| Flux CD | flux bootstrap | — | v2.8.8 | flux-system | Managed in `clusters/kind/flux-system/gotk-components.yaml` — do not edit manually |
+| Cilium CNI | cilium/cilium | 1.19.4 | v1.19.5 | kube-system | |
+| Hubble Relay | (bundled with Cilium) | 1.19.4 | v1.19.5 | kube-system | |
+| Hubble UI | (bundled with Cilium) | — | 0.13.1 | kube-system | Disabled by default; enable via `hubble.ui.enabled: true` in `cilium.yaml` |
+| cert-manager | cert-manager/cert-manager | v1.20.2 | v1.20.2 | cert-manager | |
+| OpenEBS localpv | openebs/openebs | 4.5.0 | 4.5.0 | openebs | |
+| istio-base | istio/base | 1.30.1 | 1.30.1 | istio-system | |
+| istiod | istio/istiod | 1.30.1 | 1.30.1 | istio-system | |
+| Gateway API CRDs | kubernetes-sigs/gateway-api | — | v1.2.1 | (cluster-scoped) | |
+| Envoy Gateway | envoy-gateway/gateway-helm | 1.8.1 | v1.8.1 | envoy-gateway-system | |
+| Envoy Gateway data-plane | gatewayClassName: eg | — | distroless-v1.38.1 | envoy-gateway-system | Auto-provisioned by Envoy Gateway controller when the `Gateway` CR is created; uses Gateway API (HTTPRoute) |
+| Contour | projectcontour/contour | 0.6.0 | 1.33.5 | contour | HTTPProxy CRD control plane; streams xDS to its Envoy DaemonSet over gRPC port 8001 |
+| Contour Envoy data-plane | (bundled with Contour chart) | 0.6.0 | v1.35.10 | contour | DaemonSet data plane; separate from the pods auto-provisioned by Envoy Gateway |
+| Metrics Server | metrics-server/metrics-server | 3.13.1 | 0.8.1 | metrics-server | Powers `kubectl top` and HPA; `--kubelet-insecure-tls` required for KinD |
+| kube-prometheus-stack | prometheus-community/kube-prometheus-stack | 86.2.3 | v0.91.0 (operator) | observability | |
+| Grafana | grafana/grafana | 10.5.15 | 12.3.1 | observability | |
+| Loki | grafana/loki | 7.0.0 | 3.6.7 | observability | |
+| Promtail | grafana/promtail | 6.17.1 | 3.5.1 | observability | |
+| Grafana Tempo | grafana/tempo | 1.24.4 | 2.9.0 | observability | Single-binary mode; trace backend for the OTel pipeline |
+| OpenTelemetry Collector | open-telemetry/opentelemetry-collector | 0.158.1 | 0.153.0 | observability | Contrib distribution; OTLP ingress → Tempo export; Istio sidecar disabled |
+| Tetragon | cilium/tetragon | 1.7.0 | 1.7.0 | tetragon | |
+| Kyverno | kyverno/kyverno | 3.8.1 | v1.18.1 | kyverno | |
+| Kubescape | kubescape/kubescape-operator | 1.40.2 | v4.0.8 | kubescape | NSA + MITRE continuous scan; vulnerability scan disabled for KinD |
+| Falco + Falcosidekick | falcosecurity/falco | 9.1.0 | 0.44.1 / 2.32.0 | falco | |
+| Trivy Operator | aquasecurity/trivy-operator | 0.33.1 | 0.31.1 | trivy-system | Image CVE scanning — VulnerabilityReport CRDs + Prometheus metrics; `ignoreUnfixed: true` |
+| demo (httpbin) | kennethreitz/httpbin | — | @sha256:599fe5… | demo | No versioned tags published; pinned by digest |
+| iperf3 server | networkstatic/iperf3 | — | multiarch | iperf3 | TCP bandwidth measurement; BackendTrafficPolicy enforces `maxConnections: 10` circuit-breaker |
+| BOINC | boinc/client | — | arm64v8 | boinc | Voluntary compute — Rosetta@Home + Einstein@Home; capped at 1 CPU core for thermal management |
+| Renovate | renovatebot/github-action | — | — | — | Automated dependency PRs for Helm charts, images, GitHub Actions, and CI tool pins |
+| Gitleaks | gitleaks/gitleaks | — | — | — | Secret scanning on every PR — detects accidentally committed credentials before merge |
 
 ## Container Images
 
@@ -241,24 +244,25 @@ Images referenced directly in manifests (outside of Helm charts). Helm-managed w
 
 The versions below were validated together. When upgrading a component, verify compatibility with its neighbours — Istio and Envoy Gateway both consume Gateway API CRDs, and Cilium + Istio share the sidecar interception ports.
 
-| Component | Validated Version | Constrained By |
-|---|---|---|
-| Kubernetes (KinD node) | v1.36.1 | `K8S_VER` in `versions.env` |
-| Cilium | 1.19.4 | `cilium.yaml` chart constraint + `versions.env` |
-| Istio | 1.30.1 | `istio.yaml` chart constraint + `versions.env` |
-| Envoy Gateway | 1.8.1 | `envoy-gateway.yaml` + `versions.env` |
-| Contour | 0.6.0 (app v1.33.5) | `contour.yaml` chart constraint `0.x`; `CONTOUR_VERSION` in `versions.env` (informational — not pre-installed by bootstrap) |
-| Gateway API CRDs | v1.2.1 | Hardcoded in `setup-fluxcd-gitops-kind-multinode.sh` step 4 |
-| kube-prometheus-stack | 86.2.2 | `prometheus/helmrelease.yaml` |
-| Loki | 7.0.0 | `loki/helmrelease.yaml` |
-| Grafana | 10.5.15 | `grafana/helmrelease.yaml` |
-| Grafana Tempo | 1.24.4 | `tempo/helmrelease.yaml` |
-| OpenTelemetry Collector | 0.158.1 | `opentelemetry/helmrelease.yaml` |
-| Kyverno | 3.8.1 | `kyverno.yaml` |
-| Kubescape | 1.40.2 | `kubescape.yaml` |
-| Falco | 9.1.0 | `falco.yaml` |
-| Tetragon | 1.7.0 | `tetragon.yaml` |
-| Trivy Operator | 0.33.1 | `trivy.yaml` |
+| Component | Chart Version | App Version | Constrained By |
+|---|---|---|---|
+| Kubernetes (KinD node) | — | v1.36.1 | `K8S_VER` in `versions.env` |
+| Flux CD | — | v2.8.8 | `flux bootstrap github` — update by re-running bootstrap with a newer CLI |
+| Cilium | 1.19.4 | v1.19.5 | `cilium.yaml` chart constraint (`1.19.x`) + `versions.env` |
+| Istio | 1.30.1 | 1.30.1 | `istio.yaml` chart constraint (`1.30.x`) + `versions.env` |
+| Envoy Gateway | 1.8.1 | v1.8.1 | `envoy-gateway.yaml` chart constraint (`1.8.x`) + `versions.env` |
+| Contour | 0.6.0 | 1.33.5 | `contour.yaml` chart constraint (`0.x`); `CONTOUR_VERSION` in `versions.env` (informational — Contour is installed by Flux, not the bootstrap script) |
+| Gateway API CRDs | — | v1.2.1 | Hardcoded in `setup-fluxcd-gitops-kind-multinode.sh` step 4 |
+| kube-prometheus-stack | 86.2.3 | v0.91.0 (operator) | `prometheus/helmrelease.yaml` chart constraint (`86.x`) |
+| Loki | 7.0.0 | 3.6.7 | `loki/helmrelease.yaml` chart constraint (`7.x`) |
+| Grafana | 10.5.15 | 12.3.1 | `grafana/helmrelease.yaml` chart constraint (`10.x`) |
+| Grafana Tempo | 1.24.4 | 2.9.0 | `tempo/helmrelease.yaml` chart constraint (`1.x`) |
+| OpenTelemetry Collector | 0.158.1 | 0.153.0 | `opentelemetry/helmrelease.yaml` chart constraint (`0.158.x`) |
+| Kyverno | 3.8.1 | v1.18.1 | `kyverno.yaml` chart constraint (`3.x`) |
+| Kubescape | 1.40.2 | v4.0.8 | `kubescape.yaml` chart constraint (`1.40.x`) |
+| Falco | 9.1.0 | 0.44.1 | `falco.yaml` chart constraint (`9.x`) |
+| Tetragon | 1.7.0 | 1.7.0 | `tetragon.yaml` chart constraint (`1.7.x`) |
+| Trivy Operator | 0.33.1 | 0.31.1 | `trivy.yaml` chart constraint (`0.x`) |
 
 All version pins shared between the Makefile and setup script are sourced from `versions.env` at the repository root. Updating them there propagates the change to both consumers.
 
@@ -499,31 +503,64 @@ spec:
 
 Then add a hostname-specific `server {}` block to the nginx ConfigMap in `apps/overlays/kind/istio/nodeport-proxy.yaml` — placed before the `listen 8888 default_server` catch-all block — that proxies the new hostname to `contour-contour-envoy.contour.svc.cluster.local:80`. See the existing `httpbin-contour.local` block as the template.
 
+### Network Policy Coverage
+
+Every namespace in this cluster uses a **default-deny** model. A `NetworkPolicy` with `policyTypes: [Ingress, Egress]` and an empty pod selector is applied first, blocking all traffic. Subsequent policies open only the paths each workload legitimately needs. The Cilium CNI enforces all policies using eBPF kernel programs rather than iptables rules.
+
+| Namespace | Status | Source File |
+|---|---|---|
+| `envoy-gateway-system` | Locked down | `infrastructure/controllers/envoy-gateway.yaml` |
+| `envoy-ingress` | Locked down | `infrastructure/controllers/envoy-gateway.yaml` |
+| `falco` | Locked down | `infrastructure/controllers/falco.yaml` |
+| `kubescape` | Locked down | `infrastructure/controllers/kubescape.yaml` |
+| `trivy-system` | Locked down | `infrastructure/controllers/trivy.yaml` |
+| `cert-manager` | Locked down | `infrastructure/controllers/cert-manager.yaml` |
+| `kyverno` | Locked down | `infrastructure/controllers/kyverno.yaml` |
+| `istio-system` | Locked down | `infrastructure/controllers/istio.yaml` |
+| `metrics-server` | Locked down | `infrastructure/controllers/metrics-server.yaml` |
+| `tetragon` | Locked down | `infrastructure/controllers/tetragon.yaml` |
+| `openebs` | Locked down | `infrastructure/controllers/openebs.yaml` |
+| `contour` | Locked down | `infrastructure/controllers/contour.yaml` |
+| `observability` | Locked down | `apps/base/prometheus/netpol.yaml`, `apps/base/opentelemetry/netpol.yaml` |
+| `demo` | Locked down | `apps/base/demo/netpol.yaml` |
+| `iperf3` | Locked down | `apps/base/iperf3/networkpolicies.yaml` |
+| `boinc` | Locked down | `apps/base/boinc/netpol.yaml` |
+| `flux-system` | Partially open | Managed by Flux bootstrap (`gotk-components.yaml`); unrestricted egress by design |
+
+`flux-system` NetworkPolicies are installed by the Flux bootstrapper and are not controlled by this repository. The egress is intentionally unrestricted so Flux controllers can reach any Git host or OCI registry. The scrape ingress policy permits port 8080 from any namespace — a known limitation of the upstream default.
+
 ### Adding CiliumNetworkPolicies
 
-`apps/overlays/kind/cilium/` is a placeholder for `CiliumNetworkPolicy` resources. The CNI itself is managed in `infrastructure/controllers/cilium.yaml`; this overlay is where network segmentation policy is defined. To activate:
+`CiliumNetworkPolicy` extends standard Kubernetes NetworkPolicy with capabilities that standard policies cannot express — specifically, matching traffic from the Kubernetes API server or from remote cluster nodes, both of which originate outside the pod CIDR range. One `CiliumNetworkPolicy` is already deployed in `kubescape` to permit the aggregated API server traffic on port 8443.
+
+For new `CiliumNetworkPolicy` resources that belong in the apps layer, use the placeholder overlay at `apps/overlays/kind/cilium/`:
 
 1. Add `CiliumNetworkPolicy` manifests under `apps/overlays/kind/cilium/`.
-2. Create `apps/overlays/kind/cilium/kustomization.yaml` listing them.
+2. Update `apps/overlays/kind/cilium/kustomization.yaml` to list them.
 3. Uncomment `- cilium/` in `apps/overlays/kind/kustomization.yaml`.
 
-Example deny-all default with explicit allow:
+Example — deny all traffic to a namespace, then allow one caller:
 
 ```yaml
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: deny-all
-  namespace: demo
+  name: allow-apiserver-webhook
+  namespace: my-namespace
 spec:
-  endpointSelector: {}
+  endpointSelector:
+    matchLabels:
+      app: my-webhook
   ingress:
-    - fromEndpoints:
-        - matchLabels:
-            app: allowed-caller
+    - fromEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "9443"
+              protocol: TCP
 ```
 
-Without any `CiliumNetworkPolicy` resources, all pod-to-pod traffic is permitted (Cilium's default). Add policies incrementally to harden namespaces as required.
+Use `fromEntities: kube-apiserver` when the API server must call a webhook (Kyverno, cert-manager, Istio injection). Use `fromEntities: remote-node` when cross-node traffic originates from a host-network pod on another node.
 
 ## Monitoring
 

--- a/docs/boinc.md
+++ b/docs/boinc.md
@@ -34,6 +34,19 @@ Project credentials are stored in a SOPS-encrypted Secret (`boinc-projects-secre
 - **First start** — files do not exist on the host. `cp -n` copies them. BOINC reads them on startup and attaches to both projects.
 - **Restart** — files already exist from the previous run. `cp -n` skips them. BOINC preserves its full project state, including task progress and downloaded work units.
 
+### Network Policy
+
+The `boinc` namespace uses a **default-deny** NetworkPolicy that blocks all ingress and all egress by default. A second policy then permits only the traffic BOINC actually requires:
+
+| Direction | Port | Purpose |
+|-----------|------|---------|
+| Egress | 53 UDP/TCP | DNS resolution |
+| Egress | 80, 443 TCP | BOINC project server communication |
+
+No ingress is allowed. BOINC is a pure compute client — it connects outward to project servers and never accepts inbound connections. The Cilium CNI enforces both policies using eBPF.
+
+Source file: [apps/base/boinc/netpol.yaml](../apps/base/boinc/netpol.yaml)
+
 ### CPU Limit and Thermal Management
 
 The DaemonSet is capped at `1000m` (1 CPU core out of 10 on the M5 chip). On the passively cooled MacBook Air M5, this keeps peak core temperatures below 65°C. Raising the limit above 1500m pushes cores to 74°C+, which is within Apple Silicon's safe operating range but above the thermal target for this cluster.

--- a/docs/key_concepts.md
+++ b/docs/key_concepts.md
@@ -26,7 +26,7 @@ Manages Pods that require a stable identity and dedicated persistent storage. Ea
 
 ### Namespace
 
-A virtual partition for grouping resources, applying access controls, and scoping policies. Namespaces are not a hard security boundary — Pods in different Namespaces can communicate unless a NetworkPolicy prevents it. This cluster uses approximately 15 Namespaces to separate concerns and target Kyverno policies per-namespace.
+A virtual partition for grouping resources, applying access controls, and scoping policies. Namespaces are not a hard security boundary — Pods in different Namespaces can communicate unless a NetworkPolicy prevents it. This cluster uses approximately 20 Namespaces to separate concerns and target Kyverno policies per-namespace.
 
 ### Service
 
@@ -96,6 +96,29 @@ The **Container Network Interface (CNI)** assigns IP addresses to Pods and route
 - Runs **Hubble**, a built-in observability layer that shows live traffic flows, dropped packets, and per-service metrics without any application code changes
 
 eBPF programs execute inside the Linux kernel without modifying kernel source. Cilium uses them to intercept and process every network packet at the lowest possible level.
+
+---
+
+## Network Segmentation — NetworkPolicy
+
+A **NetworkPolicy** is a Kubernetes object that restricts which pods may communicate with which other pods. Without any NetworkPolicy in place, every pod in every namespace can reach every other pod — the cluster is effectively flat. Once any NetworkPolicy selects a pod, only the traffic that policy explicitly permits is allowed; all other traffic is silently dropped.
+
+This cluster uses a **default-deny** model. Every namespace receives a policy that blocks all ingress and egress by default. Subsequent allow-policies then open only the specific communication paths each workload actually requires. The Cilium CNI enforces these policies using eBPF kernel programs — no iptables rules are involved.
+
+**What a default-deny model provides:**
+
+If an attacker gains remote code execution inside any container, they cannot reach other services in the cluster. A compromised `demo` pod cannot connect to Prometheus, Loki, Grafana, or the BOINC credentials secret — the only connections it can make are the ones the policy explicitly permits.
+
+**An example of how allow-policies work:**
+
+Prometheus must scrape metrics from pods in many different namespaces. Because those target namespaces and ports change as new components are added, Prometheus pods receive an unrestricted egress policy rather than a fixed list of targets. All other pods in the `observability` namespace remain limited to DNS, the Kubernetes API server, and intra-namespace communication. The least-privilege principle is applied as narrowly as each workload permits.
+
+**CiliumNetworkPolicy** extends standard Kubernetes NetworkPolicy with two capabilities needed in this cluster:
+
+- `fromEntities: kube-apiserver` — matches traffic from the Kubernetes API server, which originates from the control-plane's host network and has no pod-CIDR IP address. Standard NetworkPolicy cannot match it.
+- `fromEntities: remote-node` — matches traffic from host-network pods on other cluster nodes.
+
+Standard NetworkPolicy cannot express either of these because neither the API server nor a remote node has an IP address inside the pod CIDR range.
 
 ---
 
@@ -299,14 +322,14 @@ kubectl get vulnerabilityreports -A
 
 **Observability** means being able to answer "what is the cluster doing right now?" without modifying any application code. This cluster uses six tools that each capture a different type of signal and feed them into a single dashboard system.
 
-| Tool | What It Captures | Chart Version |
-|------|-----------------|---------------|
-| **Prometheus** (`kube-prometheus-stack`) | Metrics — numbers over time (CPU %, request rate, error count) | 86.2.2 |
-| **Grafana** | Dashboards — visual graphs and tables built from Prometheus and Loki data | 10.5.15 |
-| **Loki** | Logs — the text output of every container in the cluster | 7.0.0 |
-| **Promtail** | Log collector — a DaemonSet that reads log files on each node and ships them to Loki | 6.17.1 |
-| **Grafana Tempo** | Distributed traces — records the full path a request takes through multiple services | 1.24.4 |
-| **OpenTelemetry Collector** | Trace pipeline — receives OTLP trace spans from Istio Envoy sidecars and forwards them to Tempo | 0.158.1 |
+| Tool | What It Captures | Chart Version | App Version |
+|------|-----------------|---------------|-------------|
+| **Prometheus** (`kube-prometheus-stack`) | Metrics — numbers over time (CPU %, request rate, error count) | 86.2.3 | v0.91.0 (operator) |
+| **Grafana** | Dashboards — visual graphs and tables built from Prometheus and Loki data | 10.5.15 | 12.3.1 |
+| **Loki** | Logs — the text output of every container in the cluster | 7.0.0 | 3.6.7 |
+| **Promtail** | Log collector — a DaemonSet that reads log files on each node and ships them to Loki | 6.17.1 | 3.5.1 |
+| **Grafana Tempo** | Distributed traces — records the full path a request takes through multiple services | 1.24.4 | 2.9.0 |
+| **OpenTelemetry Collector** | Trace pipeline — receives OTLP trace spans from Istio Envoy sidecars and forwards them to Tempo | 0.158.1 | 0.153.0 |
 
 **How they connect:**
 

--- a/docs/kubescape-security.md
+++ b/docs/kubescape-security.md
@@ -14,7 +14,7 @@ This document records Kubescape scan findings that have been reviewed and formal
 **Severity:** Medium
 
 **Description:**
-The Grafana Helm chart injects the admin password into the pod via the `GF_SECURITY_ADMIN_PASSWORD` environment variable. This is an internal chart behaviour triggered by the `adminPassword` values key and cannot be modified without forking the upstream chart.
+The Grafana Helm chart injects the admin password into the pod via the `GF_SECURITY_ADMIN_PASSWORD` environment variable. This is an internal chart behavior triggered by the `adminPassword` values key and cannot be modified without forking the upstream chart.
 
 **Rationale for acceptance:**
 - The secret value is sourced from a Kubernetes `Secret` object (`grafana-admin-secret`) via Flux's `valuesFrom` mechanism, not hardcoded in any manifest.

--- a/docs/trivy.md
+++ b/docs/trivy.md
@@ -1,6 +1,6 @@
 # Trivy Operator — Vulnerability & Security Scanning
 
-Cluster: `flux-kind` · Operator namespace: `trivy-system` · Config: `infrastructure/controllers/trivy.yaml`
+Cluster: `flux-kind` · Operator namespace: `trivy-system` · Chart: `0.33.1` · App: `0.31.1` · Config: `infrastructure/controllers/trivy.yaml`
 
 ---
 

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -87,7 +87,7 @@ Traffic path: `localhost:8080 → KinD extraPortMapping (containerPort 8888) →
 ### Prerequisite — /etc/hosts (One-Time)
 
 ```bash
-echo "127.0.0.1 grafana.local prometheus.local" | sudo tee -a /etc/hosts
+echo "127.0.0.1 grafana.local prometheus.local httpbin-contour.local" | sudo tee -a /etc/hosts
 ```
 
 ### Quick Reference

--- a/images/deployment-process.svg
+++ b/images/deployment-process.svg
@@ -53,12 +53,12 @@
   <!-- two side-by-side cards -->
   <rect x="20" y="296" width="570" height="78" rx="8" fill="white" stroke="#C2410C" stroke-width="1.5"/>
   <text x="305" y="315" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">Pre-pull &amp; load Cilium images</text>
-  <text x="305" y="330" text-anchor="middle" font-size="9" fill="#475569">Pull v1.19.4 images from registry (including cilium-envoy, hubble-relay)</text>
+  <text x="305" y="330" text-anchor="middle" font-size="9" fill="#475569">Pull v1.19.5 images from registry (including cilium-envoy, hubble-relay)</text>
   <text x="305" y="345" text-anchor="middle" font-size="9" fill="#475569">docker save | ctr import → all 3 KinD nodes in parallel</text>
   <text x="305" y="360" text-anchor="middle" font-size="9" fill="#475569">--platform linux/arm64 (Apple Silicon)</text>
 
   <rect x="610" y="296" width="570" height="78" rx="8" fill="white" stroke="#C2410C" stroke-width="1.5"/>
-  <text x="895" y="315" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">helm install cilium v1.19.4  (direct — bypasses Flux)</text>
+  <text x="895" y="315" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">helm install cilium v1.19.5  (direct — bypasses Flux)</text>
   <text x="895" y="330" text-anchor="middle" font-size="9" fill="#475569">kubeProxyReplacement=true  ·  routingMode=tunnel  ·  tunnelProtocol=vxlan</text>
   <text x="895" y="345" text-anchor="middle" font-size="9" fill="#475569">Hubble metrics: DNS, drop, TCP, flow, port-distribution, ICMP, HTTPv2</text>
   <text x="895" y="360" text-anchor="middle" font-size="9" fill="#475569">Wait: cilium DaemonSet (300s)  ·  cilium-operator (120s)  ·  CoreDNS (120s)</text>

--- a/images/technology-map.svg
+++ b/images/technology-map.svg
@@ -75,7 +75,7 @@
   <!-- 5 cards: edges 168,344,520,696,872  centers 248,424,600,776,952 -->
   <rect x="168" y="209" width="160" height="46" rx="8" fill="white" stroke="#0891B2" stroke-width="1.5"/>
   <text x="248" y="227" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">Cilium</text>
-  <text x="248" y="242" text-anchor="middle" font-size="9"  fill="#475569">v1.19.4 · CNI + eBPF</text>
+  <text x="248" y="242" text-anchor="middle" font-size="9"  fill="#475569">v1.19.5 · CNI + eBPF</text>
 
   <rect x="344" y="209" width="160" height="46" rx="8" fill="white" stroke="#0891B2" stroke-width="1.5"/>
   <text x="424" y="227" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">Hubble</text>


### PR DESCRIPTION
## Summary

- **README.md**: Split single "Version" column into separate "Chart Version" and "App Version" columns in both the Deployed Components table and Version Compatibility table; added explanatory paragraph; added Flux CD row; corrected kube-prometheus-stack to `86.2.3`; added new "Network Policy Coverage" section documenting the default-deny status for every namespace; updated CiliumNetworkPolicy guidance with concrete `fromEntities` examples
- **docs/key_concepts.md**: Added "Network Segmentation — NetworkPolicy" section explaining the default-deny model, how CiliumNetworkPolicy extends standard NetworkPolicy, and why the model limits lateral movement after a compromise; added App Version column to the observability tools table with correct values; updated namespace count from 15 to 20
- **docs/boinc.md**: Added Network Policy subsection documenting the default-deny ingress block and explicit egress allow rules added for the boinc namespace in PR #102
- **docs/kubescape-security.md**: Fixed British spelling "behaviour" → "behavior"
- **docs/trivy.md**: Added chart version (`0.33.1`) and app version (`0.31.1`) to the header line
- **docs/troubleshooting-guide.md**: Added `httpbin-contour.local` to the `/etc/hosts` one-time prerequisite command (the README already had all three hostnames; this brings the troubleshooting guide into alignment)
- **images/deployment-process.svg**: Updated two Cilium version labels from `v1.19.4` to `v1.19.5`
- **images/technology-map.svg**: Updated one Cilium version label from `v1.19.4` to `v1.19.5`

## Style

All documentation was reviewed against *The Elements of Style* (Strunk & White): active voice, no contractions, formal tone, tenth-grade reading level, specific and concrete language. No changes were required to `docs/renovate.md`, `docs/sops-age-secrets.md`, `docs/post-quantum-readiness.md`, `docs/iperf3.md`, `docs/ISTIO_basic_notes.md`, or `docs/ISTIO_advanced_notes.md` — all were already accurate and well-written.

## Test plan

- [ ] `README.md` tables render correctly (both Chart Version and App Version columns visible)
- [ ] `docs/key_concepts.md` NetworkPolicy section appears between CNI and Istio sections
- [ ] SVG diagrams show `v1.19.5` in Cilium labels
- [ ] CI (`validate.yaml`) passes: kustomize build, Kyverno tests, Kubescape scan