### PR TITLE
docs: post-Envoy-Gateway audit — version refresh and full EG removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ The "Chart Version" column is the Helm chart release version. The "App Version" 
 | Component | Chart / Source | Chart Version | App Version | Namespace | Notes |
 |---|---|---|---|---|---|
 | Flux CD | flux bootstrap | — | v2.8.8 | flux-system | Managed in `clusters/kind/flux-system/gotk-components.yaml` — do not edit manually |
-| Cilium CNI | cilium/cilium | 1.19.4 | v1.19.5 | kube-system | |
-| Hubble Relay | (bundled with Cilium) | 1.19.4 | v1.19.5 | kube-system | |
+| Cilium CNI | cilium/cilium | 1.19.5 | v1.19.5 | kube-system | |
+| Hubble Relay | (bundled with Cilium) | 1.19.5 | v1.19.5 | kube-system | |
 | Hubble UI | (bundled with Cilium) | — | 0.13.1 | kube-system | Disabled by default; enable via `hubble.ui.enabled: true` in `cilium.yaml` |
 | cert-manager | cert-manager/cert-manager | v1.20.2 | v1.20.2 | cert-manager | |
 | OpenEBS localpv | openebs/openebs | 4.5.0 | 4.5.0 | openebs | |
@@ -203,7 +203,7 @@ The "Chart Version" column is the Helm chart release version. The "App Version" 
 | Loki | grafana/loki | 7.0.0 | 3.6.7 | observability | |
 | Promtail | grafana/promtail | 6.17.1 | 3.5.1 | observability | |
 | Grafana Tempo | grafana/tempo | 1.24.4 | 2.9.0 | observability | Single-binary mode; trace backend for the OTel pipeline |
-| OpenTelemetry Collector | open-telemetry/opentelemetry-collector | 0.158.1 | 0.153.0 | observability | Contrib distribution; OTLP ingress → Tempo export; Istio sidecar disabled |
+| OpenTelemetry Collector | open-telemetry/opentelemetry-collector | 0.158.2 | 0.153.0 | observability | Contrib distribution; OTLP ingress → Tempo export; Istio sidecar disabled |
 | Tetragon | cilium/tetragon | 1.7.0 | 1.7.0 | tetragon | |
 | Kyverno | kyverno/kyverno | 3.8.1 | v1.18.1 | kyverno | |
 | Kubescape | kubescape/kubescape-operator | 1.40.2 | v4.0.8 | kubescape | NSA + MITRE continuous scan; vulnerability scan disabled for KinD |
@@ -237,14 +237,14 @@ The versions below were validated together. When upgrading a component, verify c
 |---|---|---|---|
 | Kubernetes (KinD node) | — | v1.36.1 | `K8S_VER` in `versions.env` |
 | Flux CD | — | v2.8.8 | `flux bootstrap github` — update by re-running bootstrap with a newer CLI |
-| Cilium | 1.19.4 | v1.19.5 | `cilium.yaml` chart constraint (`1.19.x`) + `versions.env` |
+| Cilium | 1.19.5 | v1.19.5 | `cilium.yaml` chart constraint (`1.19.x`) + `versions.env` |
 | Istio | 1.30.1 | 1.30.1 | `istio.yaml` chart constraint (`1.30.x`) + `versions.env` |
 | Contour | 0.6.0 | 1.33.5 | `contour.yaml` chart constraint (`0.x`); `CONTOUR_VERSION` in `versions.env` (informational — Contour is installed by Flux, not the bootstrap script) |
 | kube-prometheus-stack | 86.2.3 | v0.91.0 (operator) | `prometheus/helmrelease.yaml` chart constraint (`86.x`) |
 | Loki | 7.0.0 | 3.6.7 | `loki/helmrelease.yaml` chart constraint (`7.x`) |
 | Grafana | 10.5.15 | 12.3.1 | `grafana/helmrelease.yaml` chart constraint (`10.x`) |
 | Grafana Tempo | 1.24.4 | 2.9.0 | `tempo/helmrelease.yaml` chart constraint (`1.x`) |
-| OpenTelemetry Collector | 0.158.1 | 0.153.0 | `opentelemetry/helmrelease.yaml` chart constraint (`0.158.x`) |
+| OpenTelemetry Collector | 0.158.2 | 0.153.0 | `opentelemetry/helmrelease.yaml` chart constraint (`0.158.x`) |
 | Kyverno | 3.8.1 | v1.18.1 | `kyverno.yaml` chart constraint (`3.x`) |
 | Kubescape | 1.40.2 | v4.0.8 | `kubescape.yaml` chart constraint (`1.40.x`) |
 | Falco | 9.1.0 | 0.44.1 | `falco.yaml` chart constraint (`9.x`) |

--- a/docs/key_concepts.md
+++ b/docs/key_concepts.md
@@ -38,7 +38,7 @@ A stable network endpoint that routes traffic to a set of Pods. Pods are created
 
 ### Custom Resource Definition (CRD)
 
-A CRD extends the Kubernetes API with a new resource type. Every `HelmRelease`, `Certificate`, `HTTPRoute`, and `ClusterPolicy` in this cluster is a CRD — installed by a Helm chart and managed like any native Kubernetes object. `kubectl get helmreleases -A` works because Flux registered the HelmRelease CRD at bootstrap time.
+A CRD extends the Kubernetes API with a new resource type. Every `HelmRelease`, `Certificate`, `HTTPProxy`, and `ClusterPolicy` in this cluster is a CRD — installed by a Helm chart and managed like any native Kubernetes object. `kubectl get helmreleases -A` works because Flux registered the HelmRelease CRD at bootstrap time.
 
 ### PersistentVolume / PersistentVolumeClaim (PV / PVC)
 
@@ -303,7 +303,7 @@ kubectl get vulnerabilityreports -A
 | **Loki** | Logs — the text output of every container in the cluster | 7.0.0 | 3.6.7 |
 | **Promtail** | Log collector — a DaemonSet that reads log files on each node and ships them to Loki | 6.17.1 | 3.5.1 |
 | **Grafana Tempo** | Distributed traces — records the full path a request takes through multiple services | 1.24.4 | 2.9.0 |
-| **OpenTelemetry Collector** | Trace pipeline — receives OTLP trace spans from Istio Envoy sidecars and forwards them to Tempo | 0.158.1 | 0.153.0 |
+| **OpenTelemetry Collector** | Trace pipeline — receives OTLP trace spans from Istio Envoy sidecars and forwards them to Tempo | 0.158.2 | 0.153.0 |
 
 **How they connect:**
 

--- a/docs/kubescape-security.md
+++ b/docs/kubescape-security.md
@@ -26,15 +26,15 @@ The Grafana Helm chart injects the admin password into the pod via the `GF_SECUR
 
 ---
 
-### Finding 2: Workload Exposed to Internet via Gateway API
+### Finding 2: Workload Exposed to Internet via Ingress Controller
 
-**Control:** Exposure to internet via load balancer / Gateway API
+**Control:** Exposure to internet via load balancer / ingress
 **Framework:** NSA Kubernetes Hardening Guide
-**Affected resources:** HTTPRoutes in namespace `demo` (httpbin), `observability` (Grafana, Prometheus)
+**Affected resources:** `HTTPProxy` CRs in namespace `demo` (httpbin), `observability` (Grafana, Prometheus)
 **Severity:** Medium
 
 **Description:**
-Kubescape flags workloads whose traffic is routed through a Gateway API `HTTPRoute` as potentially exposed to external networks. The cluster's Envoy Gateway `GatewayClass` presents an externally-reachable listener, and HTTPRoutes for Grafana, Prometheus, and the httpbin demonstration application are attached to it.
+Kubescape flags workloads whose traffic is routed through an ingress controller as potentially exposed to external networks. Three `HTTPProxy` CRs (`grafana.local`, `prometheus.local`, `httpbin-contour.local`) are attached to the Contour Envoy DaemonSet, which accepts traffic forwarded by the nginx nodeport-proxy on port 8888.
 
 **Rationale for acceptance:**
 - The exposure is intentional. The KinD cluster is accessible only from `localhost` via `extraPortMappings` in the node configuration. No public IP address or cloud load balancer is involved.

--- a/docs/post-quantum-readiness.md
+++ b/docs/post-quantum-readiness.md
@@ -5,9 +5,9 @@ one to the relevant NIST post-quantum standard, and gives an honest verdict on w
 be changed today vs. what requires waiting for upstream tool support.
 
 **Bottom line:** No component in this cluster can be switched to a NIST PQC algorithm
-today without losing compatibility. Every tool involved — Istio, cert-manager, Age/SOPS,
-and Envoy — does not yet support the new algorithms. The value of this document is a
-clear picture of what to watch and what to change when tool support arrives.
+today without losing compatibility. Every relevant tool — Istio, cert-manager, Age/SOPS,
+and Contour's Envoy data plane — lacks stable PQC support. The value of this document is a
+clear inventory of what to watch and what to change when tool support arrives.
 
 ---
 
@@ -92,21 +92,17 @@ aware of the need; no release date is set.
 
 ---
 
-### 4. Envoy Gateway — Ingress (HTTP Only)
+### 4. Contour — HTTP Ingress
 
-**Config:** `apps/base/envoy-gateway/gateway.yaml` · `infrastructure/controllers/envoy-gateway.yaml`
+**Config:** `infrastructure/controllers/contour.yaml` · `apps/base/contour/httproxy.yaml`
 
-The Gateway listener is plain HTTP (port 80). No TLS is configured at the ingress layer.
+Contour is the sole HTTP ingress controller. It manages its own Envoy DaemonSet via xDS and routes traffic to Grafana, Prometheus, and the httpbin demonstration workload. The listener is plain HTTP (port 80). No TLS is configured at the ingress layer.
 
-**What's at risk:** Nothing currently — there is no TLS handshake to attack.
+**What's at risk:** Nothing currently — there is no TLS handshake to attack at the ingress layer.
 
-**Future consideration:** When HTTPS is added, both the certificate key algorithm and the
-TLS handshake key exchange would need PQC variants. Envoy uses BoringSSL, which added
-experimental hybrid support (`X25519Kyber768Draft00`) in some versions, but this is not
-exposed through the Envoy Gateway API surface in any stable release.
+**Future consideration:** When HTTPS is added, both the certificate key algorithm and the TLS handshake key exchange will require PQC-capable variants. Contour's Envoy data plane uses BoringSSL, which added experimental hybrid support (`X25519Kyber768Draft00`) in some builds, but Contour does not expose this through its `HTTPProxy` or `TLSCertificateDelegation` API surface in any stable release.
 
-**Recommendation:** When HTTPS support is added to this cluster, design it PQC-ready from
-the start rather than retrofitting.
+**Recommendation:** When HTTPS support is added to this cluster, design it PQC-ready from the start rather than retrofitting. The relevant Contour feature to watch is support for custom TLS cipher suites in `HTTPProxy.spec.virtualhost.tls`.
 
 ---
 
@@ -139,7 +135,7 @@ its own built-in certificate generator (RSA or ECDSA, version-dependent).
 | SOPS + Age | X25519 key encapsulation | ML-KEM (FIPS 203) | ❌ No |
 | Istio mTLS workload certs | ECDSA P-256 | ML-DSA (FIPS 204) | ❌ No |
 | cert-manager (future issuers) | ECDSA / RSA | ML-DSA (FIPS 204) | ❌ No |
-| Envoy Gateway | None (HTTP only) | ML-KEM (FIPS 203) when HTTPS added | N/A |
+| Contour (Envoy data plane) | None (HTTP only, no TLS at ingress) | ML-KEM (FIPS 203) when HTTPS added | N/A |
 | OTel → Tempo gRPC | None (TLS disabled) | N/A | N/A |
 | Cilium Hubble PKI | ECDSA / RSA (default) | ML-DSA (FIPS 204) | ❌ No |
 
@@ -158,7 +154,7 @@ The `Post Quantum Computing` GitHub Actions workflow (`.github/workflows/pqc-wat
 | **Age / SOPS** | Age spec adds ML-KEM hybrid recipient type; SOPS ships updated `age` provider |
 | **Istio** | Citadel CA adds configurable key algorithm, or stable cert-manager PQC integration |
 | **cert-manager** | `spec.privateKey.algorithm: ML-DSA` added to the Certificate CRD |
-| **Envoy Gateway** | Stable BoringSSL PQC cipher suites exposed via `BackendTLSPolicy` or `ClientTLSPolicy` |
+| **Contour** | Custom TLS cipher suite support in `HTTPProxy.spec.virtualhost.tls` — stable BoringSSL PQC cipher suites in the Envoy data plane |
 | **Cilium** | Hubble PKI generator adds configurable key algorithm |
 
 ---

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -6,35 +6,35 @@ Configuration: `renovate.json` at repository root · Workflow: `.github/workflow
 
 ## How Renovate Works
 
-Renovate is a bot that automatically checks if your project's dependencies — the outside libraries and tools your code relies on — are out of date, then opens a pull request to update them. Think of it like a robot that reads your list of dependencies, checks whether newer versions exist, and hands you a suggested update to review.
+Renovate is an automated dependency update tool. It scans a repository for pinned dependency versions, checks upstream registries for newer releases, and opens a pull request for each detected update. Renovate operates on a schedule rather than as a persistent process — it runs, performs its work, and exits.
 
 ### Onboarding (First Run Only)
 
-The first time Renovate visits a repository, it looks for a `renovate.json` config file. If one does not exist, it creates a branch called `renovate/configure` and opens an **onboarding PR** that proposes a starter config. Renovate will not open any other PRs until that onboarding PR is merged — it requests permission before performing any update work.
+The first time Renovate scans a repository, it looks for a `renovate.json` configuration file. If none exists, it creates a branch called `renovate/configure` and opens an onboarding pull request that proposes a starter configuration. Renovate does not open any further pull requests until that onboarding pull request is merged — this design requires explicit consent before automated updates begin.
 
 ### The Pipeline
 
 Each time Renovate runs, it follows this sequence:
 
-1. **Initialize** — reads and merges all config (`renovate.json`, admin settings, defaults) and connects to the Git platform (GitHub, GitLab, etc.)
-2. **Scan** — the Manager module walks the repository file by file, extracts every dependency and its current version, and tags each one with the right datasource
-3. **Look up** — the Datasource module contacts registries (npm, Docker Hub, Helm chart repos, etc.) and fetches all available versions
-4. **Filter** — the Versioning module sorts valid upgrades based on your constraints (e.g. "only patch updates", "stay on `1.17.x`")
-5. **Create PRs** — the Platform module creates a branch and opens a PR for each update, including the changelog, how old the new version is, and how many other projects have already adopted it
-6. **Clean up** — stale branches for updates that were superseded by even newer versions are closed automatically
+1. **Initialize** — reads and merges all configuration (`renovate.json`, platform settings, and built-in defaults) and authenticates with the Git platform (GitHub, GitLab, etc.)
+2. **Scan** — the Manager module walks the repository file by file, extracts every dependency and its current version, and associates each one with the appropriate datasource
+3. **Look up** — the Datasource module contacts upstream registries (Docker Hub, Helm chart repositories, GitHub Releases, etc.) and retrieves all available versions
+4. **Filter** — the Versioning module identifies valid upgrades based on the configured constraints (for example, "patch updates only" or "stay on `1.17.x`")
+5. **Create PRs** — the Platform module creates a branch and opens a pull request for each update, including the changelog, the time elapsed since the new version was published, and adoption statistics from other projects
+6. **Clean up** — branches for updates superseded by even newer versions are closed automatically
 
-Renovate is stateless — it does not keep a database. It re-reads your repository and registries on every run, so if it crashes mid-run, the next run picks up cleanly.
+Renovate is stateless. It re-reads the repository and all registries on every run; if a run is interrupted, the next run resumes cleanly from the current repository state.
 
 ### The Four Core Modules
 
-| Module | Job | Analogy |
-|---|---|---|
-| **Manager** | Finds dependency files and reads the currently pinned versions | A reader who scans the code |
-| **Datasource** | Contacts registries to fetch available versions | A shopper who checks the store shelves |
-| **Versioning** | Decides which versions are valid upgrades | A filter that sorts good options from bad |
-| **Platform** | Talks to GitHub/GitLab to create branches and PRs | The delivery driver who submits the update |
+| Module | Responsibility |
+|---|---|
+| **Manager** | Locates dependency declaration files and reads the currently pinned versions |
+| **Datasource** | Queries upstream registries to retrieve available versions |
+| **Versioning** | Evaluates which discovered versions are valid upgrades under the configured constraints |
+| **Platform** | Communicates with GitHub or GitLab to create branches and open pull requests |
 
-Different package ecosystems use different version formats (npm uses `1.0.0-beta.1`, pip uses `1.0.0b1`, etc.) — the swappable Versioning module handles these differences per manager.
+Different package ecosystems use different version formats — npm uses `1.0.0-beta.1`, pip uses `1.0.0b1`, and so on. The Versioning module is swappable per manager to handle these differences correctly.
 
 ---
 
@@ -45,9 +45,9 @@ Renovate scans the repository for version strings and opens pull requests when n
 - **Flux HelmRelease version constraints** — `1.17.x`, `3.x`, `0.x`, etc. in `apps/` and `infrastructure/`; this includes the Contour chart constraint (`0.x` in `infrastructure/controllers/contour.yaml`)
 - **Direct container image tags** — images in Kubernetes manifests (BOINC, httpbin, etc.)
 - **GitHub Actions** — version pins in `.github/workflows/`
-- **CLI tool versions** — `versions.env` and workflow environment variables for Cilium, Istio, Envoy Gateway, Kubernetes node image, Kyverno CLI, and Kubescape
+- **CLI tool versions** — `versions.env` and workflow environment variables for Cilium, Istio, the Kubernetes node image, Kyverno CLI, and Kubescape
 
-`CONTOUR_VERSION` in `versions.env` is not tracked by a custom regex manager. Unlike Cilium, Istio, and Envoy Gateway — which must be pre-installed by the bootstrap script before Flux runs — Contour is installed entirely by Flux. The `CONTOUR_VERSION` value in `versions.env` is recorded for reference only. Renovate tracks the chart constraint (`0.x`) through the `flux` manager; when that constraint advances, Flux deploys the updated chart automatically without requiring a change to any script or bootstrap step.
+`CONTOUR_VERSION` in `versions.env` is not tracked by a custom regex manager. Unlike Cilium and Istio — which must be pre-installed by the bootstrap script before Flux runs — Contour is installed entirely by Flux. The `CONTOUR_VERSION` value in `versions.env` is recorded for reference only. Renovate tracks the chart constraint (`0.x`) through the `flux` manager; when that constraint advances, Flux deploys the updated chart automatically without requiring a change to any script or bootstrap step.
 
 ---
 

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -530,7 +530,7 @@ kubectl logs -n openebs deploy/openebs-openebs-localpv-provisioner | tail -50
 # Mesh-wide config analysis — reports misconfigurations, missing labels, port naming issues
 istioctl analyze --all-namespaces
 # What it catches:
-# Mismatched mTLS policies, broken HTTPRoute/VirtualService destinations,
+# Mismatched mTLS policies, broken VirtualService destinations,
 # missing sidecar injection webhooks, or gateways referencing non-existent secrets.
 
 # Confirm istiod is synced with all Envoy proxies (sidecars + auto-provisioned gateway)

--- a/images/architecture.svg
+++ b/images/architecture.svg
@@ -91,13 +91,13 @@
   <text x="1017" y="337" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8" font-style="italic">dependsOn: cilium</text>
 
   <!-- Row 2 (5 boxes, w=206, gap=16) ────────────────────── -->
-  <!-- Envoy Gateway -->
+  <!-- Contour -->
   <rect x="54" y="357" width="206" height="90" rx="8" fill="white" stroke="#15803D" stroke-width="2"/>
-  <text x="157" y="377" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="12" font-weight="700" fill="#15803D">Envoy Gateway 1.8.x</text>
+  <text x="157" y="377" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="12" font-weight="700" fill="#15803D">Contour 1.33.x</text>
   <line x1="62" y1="384" x2="252" y2="384" stroke="#15803D" stroke-width="0.75" opacity="0.35"/>
-  <text x="157" y="400" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9.5" fill="#475569">envoy-gateway-system</text>
-  <text x="157" y="414" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9.5" fill="#475569">GatewayClass: eg · NP 30080</text>
-  <text x="157" y="428" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9.5" fill="#475569">HTTPRoute ingress</text>
+  <text x="157" y="400" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9.5" fill="#475569">namespace: contour</text>
+  <text x="157" y="414" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9.5" fill="#475569">HTTPProxy CRs · Envoy DaemonSet</text>
+  <text x="157" y="428" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9.5" fill="#475569">sole HTTP ingress controller</text>
   <text x="157" y="441" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8" font-style="italic">dependsOn: cilium</text>
 
   <!-- Tetragon -->
@@ -179,7 +179,7 @@
   <rect x="611" y="550" width="150" height="54" rx="6" fill="#EFF6FF" stroke="#1D4ED8" stroke-width="1.25"/>
   <text x="686" y="568" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" font-weight="700" fill="#1D4ED8">Grafana 10.x</text>
   <text x="686" y="583" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">grafana/grafana · 16 dashboards</text>
-  <text x="686" y="597" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">HTTPRoute: grafana.local:8080</text>
+  <text x="686" y="597" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">HTTPProxy: grafana.local:8080</text>
 
   <!-- Tempo chip (row 2) -->
   <rect x="60" y="618" width="155" height="54" rx="6" fill="#EFF6FF" stroke="#1D4ED8" stroke-width="1.25"/>
@@ -195,7 +195,7 @@
 
   <!-- Dashboards note -->
   <text x="408" y="690" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" font-style="italic" fill="#1E40AF">16 dashboards: Cilium · Hubble · Istio · Flux · Falco · Tetragon · Kubescape · cert-manager · Node Exporter · OTel Collector</text>
-  <text x="408" y="705" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" font-style="italic" fill="#1E40AF">Prometheus also exposed via HTTPRoute: prometheus.local:8080</text>
+  <text x="408" y="705" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" font-style="italic" fill="#1E40AF">Prometheus also exposed via HTTPProxy: prometheus.local:8080</text>
 
   <!-- Scrape configs note -->
   <text x="408" y="722" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">additionalScrapeConfigs → Cilium · Falco · Tetragon · Kyverno · Kubescape · Flux (no ServiceMonitor CRD circular dependency)</text>
@@ -222,12 +222,12 @@
   <rect x="884" y="618" width="190" height="54" rx="6" fill="#FFF7ED" stroke="#C2410C" stroke-width="1.25"/>
   <text x="979" y="636" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" font-weight="700" fill="#9A3412">iperf3 server</text>
   <text x="979" y="651" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">networkstatic/iperf3:multiarch</text>
-  <text x="979" y="665" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">TCPRoute · BackendTrafficPolicy</text>
+  <text x="979" y="665" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">nginx stream proxy · port 32111</text>
 
   <text x="979" y="692" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#7C3AED">demo: Istio sidecar injected</text>
   <text x="979" y="707" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">PeerAuthentication: STRICT mTLS (port 80 PERMISSIVE)</text>
   <text x="979" y="722" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">generates istio_requests_total metrics → OTLP traces → OTel</text>
-  <text x="979" y="737" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">iperf3: maxConnections: 10 circuit-breaker · port 32111</text>
+  <text x="979" y="737" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">iperf3: nginx stream{} → ClusterIP Service · port 32111</text>
 
   <!-- ══════════════════════════════════════════════════════════
        Band 4 · Runtime Security (cross-cutting)

--- a/images/dependencies.svg
+++ b/images/dependencies.svg
@@ -205,8 +205,8 @@
   <text x="155" y="635" text-anchor="middle" font-size="8.5" fill="#475569">nginx nodeport proxy</text>
 
   <rect x="253" y="604" width="160" height="36" rx="8" fill="white" stroke="#4F46E5" stroke-width="1.5"/>
-  <text x="333" y="622" text-anchor="middle" font-size="10" font-weight="700" fill="#0F172A">envoy-gateway overlay</text>
-  <text x="333" y="635" text-anchor="middle" font-size="8.5" fill="#475569">proxy service + TCPRoute</text>
+  <text x="333" y="622" text-anchor="middle" font-size="10" font-weight="700" fill="#0F172A">contour HTTPProxy CRs</text>
+  <text x="333" y="635" text-anchor="middle" font-size="8.5" fill="#475569">grafana · prom · httpbin</text>
 
   <rect x="431" y="604" width="160" height="36" rx="8" fill="white" stroke="#4F46E5" stroke-width="1.5"/>
   <text x="511" y="622" text-anchor="middle" font-size="10" font-weight="700" fill="#0F172A">kyverno overlay</text>

--- a/images/deployment-process.svg
+++ b/images/deployment-process.svg
@@ -67,15 +67,15 @@
   <line x1="600" y1="386" x2="600" y2="392" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arr)"/>
 
   <!-- ══════════════════════════════════════════════════════════════
-       PHASE 3 · GATEWAY API CRDs  (y=394, h=106)
+       PHASE 3 · ISTIO SIDECAR IMAGE PRELOAD  (y=394, h=106)
        ══════════════════════════════════════════════════════════════ -->
   <rect x="10" y="394" width="1180" height="106" rx="10" fill="#ECFEFF" stroke="#0891B2" stroke-width="1.5"/>
-  <text x="28" y="412" font-size="10" font-weight="700" letter-spacing="1.2" fill="#0891B2">PHASE 3 · GATEWAY API CRDs</text>
+  <text x="28" y="412" font-size="10" font-weight="700" letter-spacing="1.2" fill="#0891B2">PHASE 3 · ISTIO SIDECAR IMAGE PRELOAD</text>
 
   <rect x="20" y="420" width="1160" height="68" rx="8" fill="white" stroke="#0891B2" stroke-width="1.5"/>
-  <text x="600" y="438" text-anchor="middle" font-size="12" font-weight="700" fill="#0F172A">kubectl apply — Gateway API standard-install.yaml  v1.2.1</text>
-  <text x="600" y="453" text-anchor="middle" font-size="9" fill="#475569">Installs CRDs: Gateway  ·  HTTPRoute  ·  GatewayClass  ·  TCPRoute  ·  TLSRoute  ·  ReferenceGrant</text>
-  <text x="600" y="468" text-anchor="middle" font-size="9" fill="#475569">kubectl wait --for=condition=Established (60s)  ·  Required before Envoy Gateway HelmRelease can reconcile</text>
+  <text x="600" y="438" text-anchor="middle" font-size="12" font-weight="700" fill="#0F172A">Pre-pull &amp; load Istio proxy images into all KinD nodes</text>
+  <text x="600" y="453" text-anchor="middle" font-size="9" fill="#475569">docker.io/istio/proxyv2:${ISTIO_VERSION}  ·  docker save | ctr import → all 3 nodes in parallel  ·  --platform linux/arm64</text>
+  <text x="600" y="468" text-anchor="middle" font-size="9" fill="#475569">Prevents sidecar CrashLoopBackOff on first Flux reconcile  ·  Bundled with Cilium image preload in Step 2 of the bootstrap script</text>
 
   <!-- connector -->
   <line x1="600" y1="500" x2="600" y2="506" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arr)"/>
@@ -130,7 +130,7 @@
   <rect x="20"  y="772" width="374" height="62" rx="8" fill="white" stroke="#15803D" stroke-width="1.5"/>
   <text x="207" y="790" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">HelmRepositories registered</text>
   <text x="207" y="805" text-anchor="middle" font-size="9" fill="#475569">13 chart sources added to flux-system</text>
-  <text x="207" y="820" text-anchor="middle" font-size="9" fill="#475569">Cilium · Cert-Manager · Istio · Envoy GW · Prometheus</text>
+  <text x="207" y="820" text-anchor="middle" font-size="9" fill="#475569">Cilium · Cert-Manager · Istio · Contour · Prometheus</text>
 
   <rect x="404" y="772" width="374" height="62" rx="8" fill="white" stroke="#15803D" stroke-width="1.5"/>
   <text x="591" y="790" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">Cilium HelmRelease adopted</text>
@@ -168,11 +168,11 @@
   <!-- right group: parallel installs -->
   <text x="348" y="860" font-size="9" font-weight="700" fill="#15803D">Parallel installs  (all dependsOn: Cilium)</text>
 
-  <!-- row A: envoy-gateway, tetragon, kyverno, kubescape -->
+  <!-- row A: contour, tetragon, kyverno, kubescape -->
   <!-- 4 boxes in x=348 to x=1172 = 824px. Each=(824-3*10)/4=198.5≈198, gap=10 -->
   <!-- edges: 348, 556, 764, 972  centers: 447, 655, 863, 1071 -->
   <rect x="348" y="866" width="198" height="26" rx="5" fill="#F0FDF4" stroke="#15803D" stroke-width="1"/>
-  <text x="447" y="883" text-anchor="middle" font-size="9" font-weight="700" fill="#0F172A">envoy-gateway</text>
+  <text x="447" y="883" text-anchor="middle" font-size="9" font-weight="700" fill="#0F172A">contour</text>
 
   <rect x="556" y="866" width="198" height="26" rx="5" fill="#F0FDF4" stroke="#15803D" stroke-width="1"/>
   <text x="655" y="883" text-anchor="middle" font-size="9" font-weight="700" fill="#0F172A">tetragon</text>
@@ -214,7 +214,7 @@
   <rect x="610" y="992" width="570" height="78" rx="8" fill="white" stroke="#7C3AED" stroke-width="1.5"/>
   <text x="895" y="1011" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">Workloads &amp; policies</text>
   <text x="895" y="1026" text-anchor="middle" font-size="9" fill="#475569">Istio overlay + nginx nodeport-proxy DaemonSet</text>
-  <text x="895" y="1041" text-anchor="middle" font-size="9" fill="#475569">Envoy Gateway overlay  (Gateway, TCPRoute, BackendTrafficPolicy)</text>
+  <text x="895" y="1041" text-anchor="middle" font-size="9" fill="#475569">Contour HTTPProxy CRs  (grafana · prometheus · httpbin)</text>
   <text x="895" y="1056" text-anchor="middle" font-size="9" fill="#475569">Kyverno ClusterPolicies  ·  demo (httpbin)  ·  BOINC DaemonSet</text>
 
   <!-- connector -->

--- a/images/flow.svg
+++ b/images/flow.svg
@@ -91,7 +91,7 @@
   <line x1="230" y1="437" x2="258" y2="437" stroke="#C2410C" stroke-width="1.5" opacity="0.6" marker-end="url(#arr-green)"/>
   <!-- istio-base (y=475) -->
   <line x1="230" y1="475" x2="258" y2="475" stroke="#C2410C" stroke-width="1.5" opacity="0.6" marker-end="url(#arr-green)"/>
-  <!-- Envoy Gateway (y=513) -->
+  <!-- Contour (y=513) -->
   <line x1="230" y1="513" x2="258" y2="513" stroke="#C2410C" stroke-width="1.5" opacity="0.6" marker-end="url(#arr-green)"/>
 
   <!-- Dependent HelmRelease boxes (x=262 start) -->
@@ -122,10 +122,10 @@
   <text x="471" y="472" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#15803D">istiod HR</text>
   <text x="471" y="486" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">control plane</text>
 
-  <!-- Envoy Gateway -->
+  <!-- Contour -->
   <rect x="262" y="495" width="145" height="36" rx="6" fill="white" stroke="#15803D" stroke-width="1.5"/>
-  <text x="334" y="510" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#15803D">Envoy Gateway HR</text>
-  <text x="334" y="524" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">GatewayClass: eg</text>
+  <text x="334" y="510" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#15803D">Contour HR</text>
+  <text x="334" y="524" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">HTTPProxy CRs · Envoy xDS</text>
 
   <!-- Tetragon + Kyverno + Falco + Kubescape on the right column -->
   <!-- Kyverno -->
@@ -225,16 +225,16 @@
   <text x="651" y="693" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#6D28D9">demo · iperf3 workloads</text>
   <text x="651" y="708" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">httpbin + load-generator</text>
   <text x="651" y="722" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Istio sidecar · STRICT mTLS</text>
-  <text x="651" y="736" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">iperf3 server · TCPRoute</text>
-  <text x="651" y="750" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">BackendTrafficPolicy circuit-breaker</text>
+  <text x="651" y="736" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">iperf3 server · nginx stream{}</text>
+  <text x="651" y="750" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">direct TCP to port 32111</text>
 
   <!-- Mesh + Ingress config CRs -->
   <rect x="735" y="675" width="128" height="90" rx="6" fill="white" stroke="#EA580C" stroke-width="1.5"/>
   <text x="799" y="693" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="600" fill="#C2410C">Mesh + Ingress CRs</text>
   <text x="799" y="708" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">PeerAuthentication</text>
   <text x="799" y="722" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Telemetry (OTLP traces)</text>
-  <text x="799" y="736" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Gateway + EnvoyProxy</text>
-  <text x="799" y="750" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">HTTPRoutes (grafana · prom)</text>
+  <text x="799" y="736" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">HTTPProxy CRs</text>
+  <text x="799" y="750" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">(grafana · prom · httpbin)</text>
 
   <!-- Down arrow to steady state -->
   <line x1="450" y1="790" x2="450" y2="808" stroke="#6B7280" stroke-width="1.5" marker-end="url(#arr)"/>

--- a/images/network-topology.svg
+++ b/images/network-topology.svg
@@ -148,7 +148,7 @@
   <!-- ══════════════════════════════════════════════════
        SHARED CLUSTER NAMESPACES (bottom of cluster box)
   ══════════════════════════════════════════════════ -->
-  <!-- kube-system / envoy-gateway namespace boxes -->
+  <!-- kube-system / envoy-ingress namespace boxes -->
   <rect x="34" y="490" width="290" height="70" rx="8" fill="#FFF7ED" stroke="#C2410C" stroke-width="1.25"/>
   <text x="179" y="507" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#C2410C">kube-system</text>
   <line x1="42" y1="513" x2="316" y2="513" stroke="#C2410C" stroke-width="0.75" opacity="0.35"/>
@@ -157,13 +157,12 @@
   <text x="179" y="554" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8" font-style="italic">Hubble UI: disabled (saves ~200 Mi RAM)</text>
 
   <!-- envoy-ingress namespace -->
-  <rect x="338" y="490" width="290" height="84" rx="8" fill="#FFF7ED" stroke="#EA580C" stroke-width="1.25"/>
+  <rect x="338" y="490" width="290" height="70" rx="8" fill="#FFF7ED" stroke="#EA580C" stroke-width="1.25"/>
   <text x="483" y="507" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#C2410C">envoy-ingress · iperf3 namespaces</text>
   <line x1="346" y1="513" x2="620" y2="513" stroke="#EA580C" stroke-width="0.75" opacity="0.35"/>
-  <text x="483" y="528" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">Envoy Gateway proxy Deployment</text>
-  <text x="483" y="542" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">NodePort Service :30080 (→ localhost:8080)</text>
-  <text x="483" y="556" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">HTTPRoute: grafana.local · prometheus.local</text>
-  <text x="483" y="570" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#C2410C">TCPRoute: iperf3 :32111 → iperf3 ns (circuit-breaker)</text>
+  <text x="483" y="528" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">nginx nodeport-proxy DaemonSet (hostNetwork: true)</text>
+  <text x="483" y="542" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">port 8888 → Contour Envoy DaemonSet :80 (HTTP)</text>
+  <text x="483" y="556" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">port 9111 → iperf3 svc :32111 (TCP stream)</text>
 
   <!-- flux-system + cert-manager etc -->
   <rect x="642" y="490" width="424" height="70" rx="8" fill="#EEF2FF" stroke="#4F46E5" stroke-width="1.25"/>
@@ -220,9 +219,9 @@
 
   <!-- Ingress path label -->
   <text x="34" y="592" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#EA580C">HTTP ingress path:</text>
-  <text x="34" y="606" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">localhost:8080 → KinD containerPort:8888 → nginx (hostNetwork) → envoy-proxy ClusterIP → HTTPRoute → Service</text>
+  <text x="34" y="606" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">localhost:8080 → KinD containerPort:8888 → nginx (hostNetwork) :8888 → Contour Envoy DaemonSet :80 → HTTPProxy → Service</text>
   <text x="34" y="619" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#C2410C">TCP ingress path (iperf3):</text>
-  <text x="34" y="633" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">localhost:32111 → KinD containerPort:9111 → nginx stream block → envoy-proxy :32111 → TCPRoute → iperf3 Service</text>
+  <text x="34" y="633" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">localhost:32111 → KinD containerPort:9111 → nginx stream{} :9111 → iperf3 Service :32111 (direct TCP, no circuit-breaker)</text>
 
   <!-- OTLP trace path -->
   <text x="34" y="648" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="10" font-weight="700" fill="#0D9488">OTLP trace path:</text>

--- a/images/technology-map.svg
+++ b/images/technology-map.svg
@@ -86,8 +86,8 @@
   <text x="600" y="242" text-anchor="middle" font-size="9"  fill="#475569">v1.30.1 · service mesh</text>
 
   <rect x="696" y="209" width="160" height="46" rx="8" fill="white" stroke="#0891B2" stroke-width="1.5"/>
-  <text x="776" y="227" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">Envoy Gateway</text>
-  <text x="776" y="242" text-anchor="middle" font-size="9"  fill="#475569">v1.8.1 · API gateway</text>
+  <text x="776" y="227" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">Contour</text>
+  <text x="776" y="242" text-anchor="middle" font-size="9"  fill="#475569">chart 0.6.0 · HTTP ingress</text>
 
   <rect x="872" y="209" width="160" height="46" rx="8" fill="white" stroke="#0891B2" stroke-width="1.5"/>
   <text x="952" y="227" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">nginx</text>


### PR DESCRIPTION
## Summary

- Removes all Envoy Gateway references from every document and diagram and replaces them with the current Contour-based ingress stack
- Corrects version strings: Cilium chart 1.19.4 → 1.19.5, OTel Collector chart 0.158.1 → 0.158.2
- Applies Strunk-and-White style throughout all prose: formal tone, no contractions, tenth-grade reading level

## Files changed

| File | Change |
|---|---|
| `README.md` | Cilium and OTel version corrections (4 occurrences) |
| `docs/key_concepts.md` | OTel version; `HTTPRoute` example → `HTTPProxy` |
| `docs/post-quantum-readiness.md` | Section 4 rewritten for Contour; summary and roadmap tables updated |
| `docs/kubescape-security.md` | Finding 2 references HTTPProxy CRs and nginx nodeport-proxy |
| `docs/renovate.md` | Envoy Gateway removed from tracked versions; informal prose corrected |
| `docs/troubleshooting-guide.md` | `HTTPRoute` removed from `istioctl analyze` code comment |
| `images/architecture.svg` | EG box → Contour; HTTPRoute → HTTPProxy; iperf3 tech detail updated |
| `images/flow.svg` | EG HR node → Contour HR; demo workloads and Mesh+Ingress CRs updated |
| `images/dependencies.svg` | `envoy-gateway overlay` → `contour HTTPProxy CRs` |
| `images/technology-map.svg` | Envoy Gateway v1.8.1 → Contour chart 0.6.0 |
| `images/network-topology.svg` | envoy-ingress box rewritten for nginx nodeport-proxy; path labels updated |
| `images/deployment-process.svg` | Phase 3 → Istio image preload; EG replaced with Contour throughout |

## Test plan

- [ ] Confirm no `Envoy Gateway`, `envoy-gateway`, `GatewayClass`, `TCPRoute`, or `BackendTrafficPolicy` strings remain in `docs/` or `images/`
- [ ] Verify SVG files render correctly in a browser (no broken elements from text-length overflows)
- [ ] Confirm version strings in README match `project_context.md` and deployed HelmRelease chart versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)