### PR TITLE
feat(makefile): add test-contour target for Contour ingress verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ BOOTSTRAP_IMAGES := \
         pull-images load-images cache-running \
         check-tools status watch validate check-crd-count \
         sops-setup sops-load-key \
-        test-policies test-falco test-cluster test-kubescape \
+        test-policies test-falco test-cluster test-kubescape test-contour \
         test-iperf3
 
 # ── Help ──────────────────────────────────────────────────────────────────────
@@ -319,6 +319,74 @@ test-cluster: ## Smoke-test a running cluster — Flux, Grafana, Prometheus, Lok
 	 [ "$$FAIL" = "0" ] \
 	   && printf '✓ Cluster smoke test passed\n\n' \
 	   || { printf '✗ Some checks failed — run: kubectl get pods -A\n\n'; exit 1; }
+
+# ── Contour ingress tests ─────────────────────────────────────────────────────
+
+test-contour: ## Verify Contour ingress — pods, HTTPProxy CRs, and all three HTTP routes
+	@kubectl cluster-info >/dev/null 2>&1 \
+	  || { printf '\n  ✗ No cluster — run: make bootstrap\n\n'; exit 1; }
+	@printf '\n==> Contour ingress verification\n'
+	@PASS=0; FAIL=0; \
+	 \
+	 printf '[1/6] Contour controller running... '; \
+	 if kubectl get pods -n contour -l app.kubernetes.io/component=contour \
+	      --no-headers 2>/dev/null | grep -q Running; then \
+	   printf 'ok\n'; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL\n'; FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[2/6] Contour Envoy DaemonSet running... '; \
+	 ENVOY_READY=$$(kubectl get pods -n contour -l app.kubernetes.io/component=envoy \
+	      --no-headers 2>/dev/null | grep -c Running); \
+	 if [ "$$ENVOY_READY" -gt 0 ]; then \
+	   printf 'ok (%s pod(s))\n' "$$ENVOY_READY"; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL\n'; FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[3/6] All HTTPProxy CRs valid... '; \
+	 INVALID=$$(kubectl get httpproxy -A --no-headers 2>/dev/null | grep -vc ' valid '); \
+	 TOTAL=$$(kubectl get httpproxy -A --no-headers 2>/dev/null | wc -l | tr -d ' '); \
+	 if [ "$$TOTAL" -gt 0 ] && [ "$$INVALID" = "0" ]; then \
+	   printf 'ok (%s proxy/proxies)\n' "$$TOTAL"; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL (%s invalid or missing)\n' "$$INVALID"; \
+	   kubectl get httpproxy -A --no-headers 2>/dev/null | grep -v ' valid '; \
+	   FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[4/6] Route httpbin-contour.local → HTTP 200... '; \
+	 CODE=$$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+	           -H 'Host: httpbin-contour.local' http://localhost:8080/get); \
+	 if [ "$$CODE" = "200" ]; then \
+	   printf 'ok\n'; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL (got %s)\n' "$$CODE"; FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[5/6] Route grafana.local → HTTP 302... '; \
+	 CODE=$$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+	           -H 'Host: grafana.local' http://localhost:8080/); \
+	 if [ "$$CODE" = "302" ]; then \
+	   printf 'ok\n'; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL (got %s)\n' "$$CODE"; FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[6/6] Route prometheus.local → HTTP 302... '; \
+	 CODE=$$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+	           -H 'Host: prometheus.local' http://localhost:8080/); \
+	 if [ "$$CODE" = "302" ]; then \
+	   printf 'ok\n'; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL (got %s)\n' "$$CODE"; FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '\n  result: %d/6 checks passed\n' "$$PASS"; \
+	 [ "$$FAIL" = "0" ] \
+	   && printf '✓ Contour ingress test passed\n\n' \
+	   || { printf '✗ Some checks failed — run: kubectl get httpproxy -A\n\n'; exit 1; }
 
 # ── iperf3 load tests ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds `make test-contour` — a six-check test suite that verifies the full Contour ingress stack is healthy.

## Checks

| # | Check | Pass condition |
|---|---|---|
| 1 | Contour controller pod | STATUS = Running |
| 2 | Contour Envoy DaemonSet pods | At least one Running (reports count) |
| 3 | All HTTPProxy CRs | STATUS = valid for every CR (reports count; lists any invalid) |
| 4 | Route `httpbin-contour.local` | HTTP 200 via `localhost:8080/get` |
| 5 | Route `grafana.local` | HTTP 302 via `localhost:8080/` |
| 6 | Route `prometheus.local` | HTTP 302 via `localhost:8080/` |

Checks 4–6 exercise the complete data path: KinD `extraPortMapping` → nginx nodeport-proxy → Contour Envoy DaemonSet → backend Service. A failure in any layer (nginx misconfiguration, broken HTTPProxy, backend pod down) will surface as a non-matching status code.

## Test plan

- [x] `make test-contour` passes 6/6 against live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)