### PR TITLE
feat(makefile): add test-kyverno target for live admission control verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ BOOTSTRAP_IMAGES := \
         pull-images load-images cache-running \
         check-tools status watch validate check-crd-count \
         sops-setup sops-load-key \
-        test-policies test-falco test-cluster test-kubescape test-contour \
+        test-policies test-kyverno test-falco test-cluster test-kubescape test-contour \
         test-iperf3
 
 # ── Help ──────────────────────────────────────────────────────────────────────
@@ -198,6 +198,57 @@ validate: ## Validate all kustomize manifests locally (mirrors CI validate step;
 
 test-policies: ## Run Kyverno CLI policy unit tests (requires: brew install kyverno)
 	kyverno test apps/base/kyverno/tests/
+
+# ── Kyverno live-cluster tests ────────────────────────────────────────────────
+
+test-kyverno: ## Verify Kyverno admission control — controllers, policies, and live enforcement (requires: running cluster)
+	@kubectl cluster-info >/dev/null 2>&1 \
+	  || { printf '\n  ✗ No cluster — run: make bootstrap\n\n'; exit 1; }
+	@printf '\n==> Kyverno admission control verification\n'
+	@PASS=0; FAIL=0; \
+	 \
+	 printf '[1/4] All Kyverno controllers running... '; \
+	 RUNNING=$$(kubectl get pods -n kyverno -l app.kubernetes.io/part-of=kyverno-kyverno \
+	      --no-headers 2>/dev/null | grep -c Running); \
+	 if [ "$$RUNNING" -ge 4 ]; then \
+	   printf 'ok (%s pod(s))\n' "$$RUNNING"; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL (%s/4 running)\n' "$$RUNNING"; \
+	   kubectl get pods -n kyverno --no-headers 2>/dev/null; \
+	   FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[2/4] All ClusterPolicies Ready... '; \
+	 NOT_READY=$$(kubectl get clusterpolicies --no-headers 2>/dev/null | grep -vc 'Ready'); \
+	 TOTAL_POL=$$(kubectl get clusterpolicies --no-headers 2>/dev/null | wc -l | tr -d ' '); \
+	 if [ "$$TOTAL_POL" -gt 0 ] && [ "$$NOT_READY" = "0" ]; then \
+	   printf 'ok (%s policies)\n' "$$TOTAL_POL"; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL (%s not Ready)\n' "$$NOT_READY"; \
+	   kubectl get clusterpolicies --no-headers 2>/dev/null | grep -v 'Ready'; \
+	   FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[3/4] Enforce: pod without resource limits is blocked (dry-run)... '; \
+	 if printf 'apiVersion: v1\nkind: Pod\nmetadata:\n  name: kyverno-test\n  namespace: default\nspec:\n  containers:\n  - name: t\n    image: busybox:1.36.1\n    securityContext:\n      allowPrivilegeEscalation: false\n' \
+	      | kubectl apply --dry-run=server -f - 2>&1 | grep -q 'denied the request'; then \
+	   printf 'ok — admission blocked\n'; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL — require-resource-limits policy did not block\n'; FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[4/4] Enforce: allowPrivilegeEscalation: true is blocked (dry-run)... '; \
+	 if printf 'apiVersion: v1\nkind: Pod\nmetadata:\n  name: kyverno-test\n  namespace: default\nspec:\n  containers:\n  - name: t\n    image: busybox:1.36.1\n    securityContext:\n      allowPrivilegeEscalation: true\n    resources:\n      requests:\n        cpu: 100m\n        memory: 64Mi\n      limits:\n        cpu: 100m\n        memory: 64Mi\n' \
+	      | kubectl apply --dry-run=server -f - 2>&1 | grep -q 'denied the request'; then \
+	   printf 'ok — admission blocked\n'; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL — disallow-privilege-escalation policy did not block\n'; FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '\n  result: %d/4 checks passed\n' "$$PASS"; \
+	 [ "$$FAIL" = "0" ] \
+	   && printf '✓ Kyverno admission control test passed\n\n' \
+	   || { printf '✗ Some checks failed — run: kubectl get clusterpolicies\n\n'; exit 1; }
 
 # ── Falco live-cluster tests ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds `make test-kyverno` — a four-check test suite that verifies Kyverno is actively enforcing admission policy, not just running.

## Checks

| # | Check | Pass condition |
|---|---|---|
| 1 | All 4 Kyverno controllers | admission-controller, background-controller, cleanup-controller, reports-controller all Running |
| 2 | All ClusterPolicies Ready | `kubectl get clusterpolicies` shows Ready for all 5 policies; lists any that are not |
| 3 | `require-resource-limits` enforcing | `kubectl apply --dry-run=server` with a pod that has no resource limits is denied by the admission webhook |
| 4 | `disallow-privilege-escalation` enforcing | `kubectl apply --dry-run=server` with `allowPrivilegeEscalation: true` is denied by the admission webhook |

## Design notes

Checks 3 and 4 use `kubectl apply --dry-run=server` rather than creating real resources. Server-side dry-run passes the request through the full admission webhook chain — including Kyverno — without persisting anything to etcd. This means:
- No cleanup required
- No side effects on the cluster
- Tests the actual enforcement path, not just "is Kyverno running?"

Both checks target the `default` namespace, which is outside all `Enforce`-policy exclusion lists, ensuring both policies apply.

## Test plan

- [x] `make test-kyverno` passes 4/4 against live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)