### PR TITLE
feat(makefile): add test-istio target for live service mesh verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ BOOTSTRAP_IMAGES := \
         pull-images load-images cache-running \
         check-tools status watch validate check-crd-count \
         sops-setup sops-load-key \
-        test-policies test-kyverno test-falco test-cluster test-kubescape test-contour \
+        test-policies test-istio test-kyverno test-falco test-cluster test-kubescape test-contour \
         test-iperf3
 
 # ── Help ──────────────────────────────────────────────────────────────────────
@@ -198,6 +198,72 @@ validate: ## Validate all kustomize manifests locally (mirrors CI validate step;
 
 test-policies: ## Run Kyverno CLI policy unit tests (requires: brew install kyverno)
 	kyverno test apps/base/kyverno/tests/
+
+# ── Istio service mesh tests ──────────────────────────────────────────────────
+
+test-istio: ## Verify Istio service mesh — istiod, injection, proxy sync, mTLS, and config analysis (requires: running cluster + istioctl)
+	@kubectl cluster-info >/dev/null 2>&1 \
+	  || { printf '\n  ✗ No cluster — run: make bootstrap\n\n'; exit 1; }
+	@command -v istioctl >/dev/null 2>&1 \
+	  || { printf '\n  ✗ istioctl not found — install: brew install istioctl\n\n'; exit 1; }
+	@printf '\n==> Istio service mesh verification\n'
+	@PASS=0; FAIL=0; \
+	 \
+	 printf '[1/5] istiod running... '; \
+	 if kubectl get pods -n istio-system -l app=istiod --no-headers 2>/dev/null | grep -q Running; then \
+	   printf 'ok\n'; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL\n'; FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[2/5] Injection enabled: demo and observability namespaces... '; \
+	 INJECTING=$$(kubectl get namespace demo observability \
+	      -o jsonpath='{range .items[*]}{.metadata.labels.istio-injection}{"\n"}{end}' 2>/dev/null \
+	      | grep -c '^enabled$$'); \
+	 if [ "$$INJECTING" -eq 2 ]; then \
+	   printf 'ok\n'; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL (%s/2 namespaces labelled)\n' "$$INJECTING"; FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[3/5] All proxies subscribed to istiod xDS... '; \
+	 PROXY_COUNT=$$(istioctl proxy-status 2>/dev/null | tail -n +2 | grep -c .); \
+	 SYNCED_COUNT=$$(istioctl proxy-status 2>/dev/null | tail -n +2 \
+	      | grep -c '4 (CDS,LDS,EDS,RDS)' || true); \
+	 if [ "$$PROXY_COUNT" -gt 0 ] && [ "$$PROXY_COUNT" -eq "$$SYNCED_COUNT" ]; then \
+	   printf 'ok (%s proxy/proxies)\n' "$$PROXY_COUNT"; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL (%s/%s synced)\n' "$$SYNCED_COUNT" "$$PROXY_COUNT"; \
+	   istioctl proxy-status 2>/dev/null; \
+	   FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[4/5] mTLS in use: X-Forwarded-Client-Cert header present... '; \
+	 XFCC=$$(kubectl exec -n demo deploy/load-generator -c curl -- \
+	      curl -s --max-time 5 http://httpbin.demo.svc.cluster.local/get 2>/dev/null \
+	      | grep -c 'X-Forwarded-Client-Cert' || true); \
+	 if [ "$$XFCC" -gt 0 ]; then \
+	   printf 'ok\n'; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL — header absent; Istio sidecar may not be intercepting traffic\n'; \
+	   FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '[5/5] No errors or warnings from istioctl analyze... '; \
+	 ISSUES=$$(istioctl analyze --all-namespaces 2>/dev/null \
+	      | grep -cE '^(Warning|Error)' || true); \
+	 if [ "$$ISSUES" -eq 0 ]; then \
+	   printf 'ok\n'; PASS=$$((PASS+1)); \
+	 else \
+	   printf 'FAIL (%s issue(s))\n' "$$ISSUES"; \
+	   istioctl analyze --all-namespaces 2>/dev/null | grep -E '^(Warning|Error)'; \
+	   FAIL=$$((FAIL+1)); \
+	 fi; \
+	 \
+	 printf '\n  result: %d/5 checks passed\n' "$$PASS"; \
+	 [ "$$FAIL" = "0" ] \
+	   && printf '✓ Istio service mesh test passed\n\n' \
+	   || { printf '✗ Some checks failed — run: istioctl analyze --all-namespaces\n\n'; exit 1; }
 
 # ── Kyverno live-cluster tests ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds `make test-istio` — a five-check test suite that verifies Istio's control plane and data plane are functioning end-to-end.

## Checks

| # | Check | Pass condition |
|---|---|---|
| 1 | istiod pod | Running in `istio-system` |
| 2 | Injection labels | `istio-injection: enabled` on both `demo` and `observability` namespaces |
| 3 | xDS sync | All proxies subscribed to CDS, LDS, EDS, and RDS via `istioctl proxy-status` |
| 4 | mTLS in use | `X-Forwarded-Client-Cert` header present in an in-cluster request from `load-generator` to `httpbin` |
| 5 | Config analysis | `istioctl analyze --all-namespaces` produces no `Warning` or `Error` messages (Info-level port-naming suggestions are accepted) |

## Design notes

**Check 3** (`istioctl proxy-status`) uses the Istio 1.30 output format, which reports `SUBSCRIBED TYPES` rather than a `SYNCED/NOT SYNCED` column. A proxy that subscribes to all four xDS resource types (CDS, LDS, EDS, RDS) is fully connected and receiving configuration from istiod. The check fails if any proxy has fewer than four subscriptions, or if no proxies appear at all.

**Check 4** is the most valuable check in the set. The `X-Forwarded-Client-Cert` (XFCC) header is added by the *receiving* Envoy sidecar only when the connection was established over mTLS. Its presence in the httpbin `/get` response — which echoes all request headers — proves that:
- The load-generator sidecar intercepted the outbound request
- mTLS was negotiated between the two sidecars
- The httpbin sidecar processed the connection and inserted the XFCC header with the caller's SPIFFE identity

The test uses `kubectl exec` into the existing `load-generator` pod rather than creating a temporary pod, so there are no side effects on the cluster.

**Note:** This cluster uses Istio's native Kubernetes sidecar feature (KEP-753). The `istio-proxy` container appears in `spec.initContainers` with `restartPolicy: Always` rather than `spec.containers`. Checks 1–5 do not depend on which injection mechanism is used.

## Test plan

- [x] `make test-istio` passes 5/5 against live cluster (8 proxies, XFCC header confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)