### PR TITLE
docs(kubescape): document config.json emptyDir/subPath known issue

### DIFF
--- a/infrastructure/controllers/kubescape.yaml
+++ b/infrastructure/controllers/kubescape.yaml
@@ -57,6 +57,17 @@ spec:
       # 400 "missing account id" error on every scan cycle because no account
       # or accessKey is configured. Enable offline mode to suppress this.
       kubescapeOffline: enable
+    # Known chart issue (kubescape-operator 1.40.x): the chart mounts an emptyDir
+    # volume with subPath: config.json at /home/nonroot/.kubescape/config.json.
+    # Kubernetes creates the subPath entry as a directory before any container
+    # starts, so the kubescape CLI binary finds a directory at that path instead
+    # of a writable file. This produces the following error on every scan cycle:
+    #   open /home/nonroot/.kubescape/config.json: is a directory
+    # The error is benign. It affects only local account-state persistence, which
+    # has no purpose in offline mode (kubescapeOffline: enable). Scan results
+    # flow through the operator → storage → prometheus-exporter path, which does
+    # not touch this file. Resolution: upgrade to a chart version that corrects
+    # the volume configuration. Renovate will open a PR when one is available.
     configurations:
       prometheusAnnotations: disable
 ---


### PR DESCRIPTION
## Summary

- Adds a comment to the Kubescape HelmRelease explaining the `open /home/nonroot/.kubescape/config.json: is a directory` log error that appears on every scan cycle.
- The root cause is a chart bug: the `kubescape-operator 1.40.x` chart mounts an emptyDir volume with `subPath: config.json`, which Kubernetes creates as a directory before any container starts.
- The error is benign. Scan results flow through the operator → storage → prometheus-exporter path and reach Grafana correctly. The file only stores CLI account state, which is unused in `kubescapeOffline: enable` mode.
- No functional change. The comment documents the issue so it is not mistaken for a real error, and notes that Renovate will surface a fix when a newer chart version is released.

## Test plan

- [ ] Confirm `make validate` passes (docs-only change)
- [ ] Confirm Flux reconciles successfully after merge