### PR TITLE
fix(alertmanager): disable gossip port to silence Istio TCP listener conflict

### DIFF
--- a/apps/base/prometheus/helmrelease.yaml
+++ b/apps/base/prometheus/helmrelease.yaml
@@ -39,6 +39,17 @@ spec:
       enabled: true
       alertmanagerSpec:
         logLevel: warn
+        # Disable the Alertmanager gossip/clustering port (9094).
+        # The alertmanager-operated headless service and the ClusterIP service
+        # both map to the same pod IP on port 9094. Istio sees two services
+        # claiming the same IP:port and cannot install separate outbound TCP
+        # listeners for each, logging:
+        #   pilot_conflict_outbound_listener_tcp_over_current_tcp 10.x.x.x_9094
+        # Passing an empty cluster.listen-address disables the gossip listener
+        # entirely. Clustering is unused with a single replica anyway.
+        additionalArgs:
+          - name: cluster.listen-address
+            value: ""
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
## Summary

- Adds `--cluster.listen-address=""` to Alertmanager via `alertmanagerSpec.additionalArgs`
- The `alertmanager-operated` headless service and the `observability-kube-prometh-alertmanager` ClusterIP service both expose port 9094 (gossip) on the same pod IP, causing Istio to log `pilot_conflict_outbound_listener_tcp_over_current_tcp` for that IP:port on every restart
- Disabling the gossip listener removes the port 9094 endpoint entirely; Istio no longer sees two services competing for the same address
- Alertmanager clustering is unused with `replicas: 1`; this is a no-op change in terms of alert delivery behavior

## Test plan

- [ ] Confirm Flux reconciles the kube-prometheus-stack HelmRelease successfully
- [ ] Confirm `kubectl get pod -n observability -l app.kubernetes.io/name=alertmanager` shows 3/3 Ready after rollout
- [ ] Confirm `kubectl logs -n istio-system istiod-*` no longer contains `pilot_conflict_outbound_listener_tcp_over_current_tcp` entries for `_9094`