### PR TITLE
fix(prometheus-operator): increase admission webhook timeout to 30s

### DIFF
--- a/apps/base/prometheus/helmrelease.yaml
+++ b/apps/base/prometheus/helmrelease.yaml
@@ -142,6 +142,13 @@ spec:
     # (configReloaderCpu/Memory set both requests and limits for that container).
     prometheusOperator:
       logLevel: warn
+      # Flux reconciles the monitoring-rules Kustomization every hour, which
+      # applies PrometheusRule resources and triggers these admission webhooks.
+      # The default 10-second timeout is too short when the operator is busy
+      # reconciling; increasing it to 30s (the Kubernetes maximum) eliminates
+      # the recurring "context deadline exceeded" errors in kube-apiserver logs.
+      admissionWebhooks:
+        timeoutSeconds: 30
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

- Sets `prometheusOperator.admissionWebhooks.timeoutSeconds: 30` in the kube-prometheus-stack HelmRelease
- The Prometheus Operator admission webhooks (`prometheusrulemutate` and `prometheusrulevalidate`) were timing out every hour when the Flux `monitoring-rules` Kustomization reconciled and applied `PrometheusRule` resources
- The default 10-second timeout is insufficient when the operator is mid-reconciliation; the kube-apiserver logged `context deadline exceeded` for both webhooks on a ~59-minute cycle, matching the Flux 1h reconcile interval
- Both webhooks have `failurePolicy: Ignore`, so PrometheusRules were being created without validation during each timeout window
- 30 seconds is the Kubernetes maximum admission webhook timeout

## Test plan

- [ ] Confirm Flux reconciles the kube-prometheus-stack HelmRelease successfully after merge
- [ ] Confirm `kubectl get mutatingwebhookconfiguration observability-kube-prometh-admission -o jsonpath='{.webhooks[0].timeoutSeconds}'` returns `30`
- [ ] Confirm no further `context deadline exceeded` entries in `kubectl logs -n kube-system kube-apiserver-flux-kind-control-plane` after the next Flux `monitoring-rules` reconcile (~60 minutes post-merge)