### PR TITLE
feat(flux): enable drift detection on all HelmReleases

### DIFF
--- a/apps/base/grafana/helmrelease.yaml
+++ b/apps/base/grafana/helmrelease.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: observability
   dependsOn:
     - name: kube-prometheus-stack

--- a/apps/base/loki/helmrelease.yaml
+++ b/apps/base/loki/helmrelease.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: observability
   dependsOn:
     - name: kube-prometheus-stack

--- a/apps/base/opentelemetry/helmrelease.yaml
+++ b/apps/base/opentelemetry/helmrelease.yaml
@@ -22,6 +22,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: observability
   dependsOn:
     - name: kube-prometheus-stack

--- a/apps/base/prometheus/helmrelease.yaml
+++ b/apps/base/prometheus/helmrelease.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: observability
   dependsOn:
     - name: openebs

--- a/apps/base/promtail/helmrelease.yaml
+++ b/apps/base/promtail/helmrelease.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: observability
   dependsOn:
     - name: loki

--- a/apps/base/tempo/helmrelease.yaml
+++ b/apps/base/tempo/helmrelease.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: observability
   dependsOn:
     - name: kube-prometheus-stack

--- a/infrastructure/controllers/cert-manager.yaml
+++ b/infrastructure/controllers/cert-manager.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   dependsOn:
     - name: cilium
       namespace: flux-system
@@ -80,6 +82,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: cert-manager
   dependsOn:
     - name: cert-manager-crds

--- a/infrastructure/controllers/cilium.yaml
+++ b/infrastructure/controllers/cilium.yaml
@@ -39,6 +39,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   releaseName: cilium
   targetNamespace: kube-system
   install:

--- a/infrastructure/controllers/contour.yaml
+++ b/infrastructure/controllers/contour.yaml
@@ -21,6 +21,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: contour
   dependsOn:
     - name: cilium

--- a/infrastructure/controllers/falco.yaml
+++ b/infrastructure/controllers/falco.yaml
@@ -29,6 +29,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: falco
   dependsOn:
     - name: cilium

--- a/infrastructure/controllers/istio.yaml
+++ b/infrastructure/controllers/istio.yaml
@@ -17,6 +17,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   dependsOn:
     - name: cilium
       namespace: flux-system
@@ -47,6 +49,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: istio-system
   dependsOn:
     - name: istio-base

--- a/infrastructure/controllers/kubescape.yaml
+++ b/infrastructure/controllers/kubescape.yaml
@@ -13,6 +13,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: kubescape-operator

--- a/infrastructure/controllers/kyverno.yaml
+++ b/infrastructure/controllers/kyverno.yaml
@@ -13,6 +13,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: kyverno
   dependsOn:
     - name: cilium

--- a/infrastructure/controllers/metrics-server.yaml
+++ b/infrastructure/controllers/metrics-server.yaml
@@ -26,6 +26,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: metrics-server
   dependsOn:
     - name: cilium

--- a/infrastructure/controllers/openebs.yaml
+++ b/infrastructure/controllers/openebs.yaml
@@ -13,6 +13,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   dependsOn:
     - name: cilium
       namespace: flux-system

--- a/infrastructure/controllers/tetragon.yaml
+++ b/infrastructure/controllers/tetragon.yaml
@@ -17,6 +17,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: tetragon
   dependsOn:
     - name: cilium

--- a/infrastructure/controllers/trivy.yaml
+++ b/infrastructure/controllers/trivy.yaml
@@ -23,6 +23,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  driftDetection:
+    mode: enabled
   targetNamespace: trivy-system
   dependsOn:
     - name: cilium


### PR DESCRIPTION
## Summary

- Adds `driftDetection.mode: enabled` to all 19 HelmReleases across 17 files in `infrastructure/controllers/` and `apps/base/`
- Flux will now detect out-of-band changes (manual `kubectl edit`, failed rollbacks, partial reconciliations) and reconcile them back to the Git source of truth
- No behavioral change during normal operations; only activates when cluster state diverges from the Helm release spec

## HelmReleases covered

**infrastructure/controllers** (13): cilium, cert-manager (×2), istio (×2), contour, kyverno, falco, kubescape, openebs, tetragon, trivy, metrics-server

**apps/base** (6): kube-prometheus-stack, grafana, loki, promtail, tempo, opentelemetry-collector