### PR TITLE
fix(alertmanager): use pod annotation to exclude port 9094 from Istio

### DIFF
--- a/apps/base/prometheus/helmrelease.yaml
+++ b/apps/base/prometheus/helmrelease.yaml
@@ -41,17 +41,15 @@ spec:
       enabled: true
       alertmanagerSpec:
         logLevel: warn
-        # Disable the Alertmanager gossip/clustering port (9094).
-        # The alertmanager-operated headless service and the ClusterIP service
-        # both map to the same pod IP on port 9094. Istio sees two services
-        # claiming the same IP:port and cannot install separate outbound TCP
-        # listeners for each, logging:
-        #   pilot_conflict_outbound_listener_tcp_over_current_tcp 10.x.x.x_9094
-        # Passing an empty cluster.listen-address disables the gossip listener
-        # entirely. Clustering is unused with a single replica anyway.
-        additionalArgs:
-          - name: cluster.listen-address
-            value: ""
+        podMetadata:
+          annotations:
+            # The alertmanager-operated headless service and the ClusterIP service
+            # both advertise port 9094 on the same pod IP. Istio pilot cannot
+            # install two separate outbound TCP listeners for the same IP:port,
+            # logging pilot_conflict_outbound_listener_tcp_over_current_tcp.
+            # Excluding port 9094 from Istio interception removes the conflict
+            # without touching alertmanager's own args.
+            traffic.sidecar.istio.io/excludeOutboundPorts: "9094"
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
## Summary

- Removes the broken `additionalArgs: cluster.listen-address` introduced in #118
- Adds `traffic.sidecar.istio.io/excludeOutboundPorts: "9094"` pod annotation instead

## Root cause

The Prometheus Operator renders `additionalArgs` entries with an empty `value:` field as a bare flag without `=` at the end of the args list (e.g., `--cluster.listen-address` with no value). The alertmanager binary parses that flag, finds nothing following it, and exits with:

```
alertmanager: error: expected argument for flag '--cluster.listen-address', try --help
```

This caused a crash loop for ~39 hours (2876 backoffs). The broken upgrade also prevented PR #120's `admissionWebhooks.timeoutSeconds: 30` from being applied, which in turn caused PR #121's drift detection upgrade to time out while applying 30+ PrometheusRules through the 10s webhook.

## Fix

The pod annotation `traffic.sidecar.istio.io/excludeOutboundPorts: "9094"` instructs Istio's init container to skip iptables rules for port 9094 on the alertmanager pod. This prevents Istio pilot from generating a conflicting outbound TCP listener for that port, resolving the `pilot_conflict_outbound_listener_tcp_over_current_tcp` warning without modifying alertmanager flags.

## After merge

Once Flux reconciles and the alertmanager pod restarts cleanly, a manual reconciliation of `kube-prometheus-stack` will be needed to clear the stuck `upgradeFailures: 4` state and apply the accumulated changes from PRs #120 and #121.