### PR TITLE
fix(istio-base): ignore caBundle field in drift detection

### DIFF
--- a/infrastructure/controllers/istio.yaml
+++ b/infrastructure/controllers/istio.yaml
@@ -19,6 +19,15 @@ spec:
   interval: 1h
   driftDetection:
     mode: enabled
+    ignore:
+      # istiod writes its CA bundle into this webhook at runtime. Flux must not
+      # treat that field as drift or it will overwrite the bundle every cycle and
+      # keep the HelmRelease in a permanent correcting-drift state.
+      - paths:
+          - /webhooks/0/clientConfig/caBundle
+        target:
+          kind: ValidatingWebhookConfiguration
+          name: istiod-default-validator
   dependsOn:
     - name: cilium
       namespace: flux-system


### PR DESCRIPTION
## Summary

- Adds `driftDetection.ignore` for `/webhooks/0/clientConfig/caBundle` on `ValidatingWebhookConfiguration/istiod-default-validator`

## Root cause

istiod owns the `caBundle` field in `istiod-default-validator` at runtime — it writes the current CA certificate bundle into that field so that the API server can validate webhook calls. The Helm chart ships the resource without a bundle (or with a placeholder).

With drift detection now enabled (PR #121), Flux detects the runtime-written `caBundle` as drift from the chart's desired state, patches the field back to the chart value, and emits a `DriftCorrected` event. istiod sees the field revert, restores the bundle within one second, and Flux detects drift again — a permanent loop that keeps `istio-base` in `Ready: Unknown / correcting cluster drift` and blocks `istiod` from reconciling (dependency not ready).

## Fix

The `driftDetection.ignore` rule tells Flux to skip `/webhooks/0/clientConfig/caBundle` when computing drift for that specific resource. All other fields in the webhook configuration remain under drift control.