### PR TITLE
fix(istiod): ignore caBundle fields in webhook drift detection

### DIFF
--- a/infrastructure/controllers/istio.yaml
+++ b/infrastructure/controllers/istio.yaml
@@ -60,6 +60,23 @@ spec:
   interval: 1h
   driftDetection:
     mode: enabled
+    ignore:
+      # istiod writes its CA bundle into all webhook configurations it owns at
+      # runtime. Flux must not treat those fields as drift or it will overwrite
+      # the bundle on every cycle, immediately re-drifted by istiod.
+      - paths:
+          - /webhooks/0/clientConfig/caBundle
+        target:
+          kind: ValidatingWebhookConfiguration
+          name: istio-validator-istio-system
+      - paths:
+          - /webhooks/0/clientConfig/caBundle
+          - /webhooks/1/clientConfig/caBundle
+          - /webhooks/2/clientConfig/caBundle
+          - /webhooks/3/clientConfig/caBundle
+        target:
+          kind: MutatingWebhookConfiguration
+          name: istio-sidecar-injector
   targetNamespace: istio-system
   dependsOn:
     - name: istio-base


### PR DESCRIPTION
## Summary

Adds \`driftDetection.ignore\` rules for all \`caBundle\` paths in the two webhook configurations owned by the \`istiod\` HelmRelease.

## Root cause

istiod writes its CA certificate bundle into every \`WebhookConfiguration\` it owns at runtime — this is how the Kubernetes API server learns to trust the istiod webhook endpoint. The Helm chart ships these resources with an empty or placeholder \`caBundle\`.

With drift detection enabled (PR #121), Flux detects the runtime-written \`caBundle\` as drift from the chart's desired state and patches it back. istiod detects the field revert and restores its bundle within one second. Flux detects drift again. The loop produces:

\`\`\`
DriftDetected  ValidatingWebhookConfiguration/istio-validator-istio-system changed (0 additions, 1 changes, 0 removals)
DriftCorrected ValidatingWebhookConfiguration/istio-validator-istio-system configured
\`\`\`

...repeating continuously, keeping \`istiod\` in \`Ready: Unknown / correcting cluster drift\` and blocking every HelmRelease that depends on it.

## Webhooks covered

| Resource | Kind | Webhooks |
|---|---|---|
| \`istio-validator-istio-system\` | ValidatingWebhookConfiguration | 1 — \`/webhooks/0/clientConfig/caBundle\` |
| \`istio-sidecar-injector\` | MutatingWebhookConfiguration | 4 — \`/webhooks/{0-3}/clientConfig/caBundle\` |

\`istio-base\` already has the equivalent rule for \`istiod-default-validator\` (PR #123).