### PR TITLE
fix(istiod): exclude webhook resources from drift detection entirely

### DIFF
--- a/infrastructure/controllers/istio.yaml
+++ b/infrastructure/controllers/istio.yaml
@@ -20,12 +20,9 @@ spec:
   driftDetection:
     mode: enabled
     ignore:
-      # istiod writes its CA bundle into this webhook at runtime. Flux must not
-      # treat that field as drift or it will overwrite the bundle every cycle and
-      # keep the HelmRelease in a permanent correcting-drift state.
-      - paths:
-          - /webhooks/0/clientConfig/caBundle
-        target:
+      # istiod writes its CA bundle into this webhook at runtime. Excluding the
+      # entire resource prevents the permanent correcting-drift loop.
+      - target:
           kind: ValidatingWebhookConfiguration
           name: istiod-default-validator
   dependsOn:
@@ -62,19 +59,12 @@ spec:
     mode: enabled
     ignore:
       # istiod writes its CA bundle into all webhook configurations it owns at
-      # runtime. Flux must not treat those fields as drift or it will overwrite
-      # the bundle on every cycle, immediately re-drifted by istiod.
-      - paths:
-          - /webhooks/0/clientConfig/caBundle
-        target:
+      # runtime. Excluding these resources entirely from drift detection prevents
+      # the permanent correcting-drift loop caused by the caBundle field.
+      - target:
           kind: ValidatingWebhookConfiguration
           name: istio-validator-istio-system
-      - paths:
-          - /webhooks/0/clientConfig/caBundle
-          - /webhooks/1/clientConfig/caBundle
-          - /webhooks/2/clientConfig/caBundle
-          - /webhooks/3/clientConfig/caBundle
-        target:
+      - target:
           kind: MutatingWebhookConfiguration
           name: istio-sidecar-injector
   targetNamespace: istio-system


### PR DESCRIPTION
## Summary

Switches the Istio webhook ignore rules from path-based exclusion (caBundle only) to full-resource exclusion, and applies this to all three webhook configurations managed by istiod at runtime.

## What changed and why

PR #124 used `paths: [/webhooks/0/clientConfig/caBundle]` to exclude only the caBundle field. After merging and observing helm-controller logs, the exclusion was not working (`excluded: 0` in every log line). The correction action kept running, producing a tight loop with errors:

```
failed to wait for object to sync in-cache after patching: context deadline exceeded
```

The path-based approach may not work here because the Helm chart renders the webhook **without** a caBundle field. Flux computes drift by comparing the SSA dry-run result against the live state. When the SSA result already includes caBundle (inherited from the `pilot-discovery` field manager), the "change" Flux sees is the value of caBundle shifting — not the presence of the field. The path-based ignore rule is interpreted against the diff structure, and the exact JSON Pointer may not match how Flux internally represents the change.

Switching to full-resource exclusion (no `paths` field) bypasses this entirely. The three webhook resources are fully excluded from drift comparison. All other resources in both `istio-base` and `istiod` remain under drift detection.

## Resources excluded

| Resource | Kind | Owned by |
|---|---|---|
| `istiod-default-validator` | ValidatingWebhookConfiguration | `istio-base` HelmRelease |
| `istio-validator-istio-system` | ValidatingWebhookConfiguration | `istiod` HelmRelease |
| `istio-sidecar-injector` | MutatingWebhookConfiguration | `istiod` HelmRelease |