### PR TITLE
fix(istiod): use paths: [] for webhook drift exclusion

### DIFF
--- a/infrastructure/controllers/istio.yaml
+++ b/infrastructure/controllers/istio.yaml
@@ -22,7 +22,8 @@ spec:
     ignore:
       # istiod writes its CA bundle into this webhook at runtime. Excluding the
       # entire resource prevents the permanent correcting-drift loop.
-      - target:
+      - paths: []
+        target:
           kind: ValidatingWebhookConfiguration
           name: istiod-default-validator
   dependsOn:
@@ -61,10 +62,12 @@ spec:
       # istiod writes its CA bundle into all webhook configurations it owns at
       # runtime. Excluding these resources entirely from drift detection prevents
       # the permanent correcting-drift loop caused by the caBundle field.
-      - target:
+      - paths: []
+        target:
           kind: ValidatingWebhookConfiguration
           name: istio-validator-istio-system
-      - target:
+      - paths: []
+        target:
           kind: MutatingWebhookConfiguration
           name: istio-sidecar-injector
   targetNamespace: istio-system


### PR DESCRIPTION
## Summary

Fixes CRD validation failure introduced by PR #125.

## Error

```
HelmRelease/flux-system/istio-base dry-run failed (Invalid):
spec.driftDetection.ignore[0].paths: Required value
```

## Root cause

The Flux `HelmRelease` CRD marks `paths` as a required field inside each `driftDetection.ignore` rule. PR #125 omitted the field entirely to signal full-resource exclusion, but the API server rejects the object as invalid before it can be applied.

## Fix

Replace omitted `paths` with `paths: []`. An empty list is the correct syntax for full-resource exclusion per the Flux documentation ("if paths is empty, the entire resource is excluded from drift detection").