### PR TITLE
fix(istiod): add API group to webhook drift exclusion targets

### DIFF
--- a/infrastructure/controllers/istio.yaml
+++ b/infrastructure/controllers/istio.yaml
@@ -24,6 +24,7 @@ spec:
       # entire resource prevents the permanent correcting-drift loop.
       - paths: []
         target:
+          group: admissionregistration.k8s.io
           kind: ValidatingWebhookConfiguration
           name: istiod-default-validator
   dependsOn:
@@ -64,10 +65,12 @@ spec:
       # the permanent correcting-drift loop caused by the caBundle field.
       - paths: []
         target:
+          group: admissionregistration.k8s.io
           kind: ValidatingWebhookConfiguration
           name: istio-validator-istio-system
       - paths: []
         target:
+          group: admissionregistration.k8s.io
           kind: MutatingWebhookConfiguration
           name: istio-sidecar-injector
   targetNamespace: istio-system


### PR DESCRIPTION
## Summary

Adds `group: admissionregistration.k8s.io` to all three `driftDetection.ignore` targets in `istio-base` and `istiod`.

## Root cause

After merging PR #126 (`paths: []`), the ignore rules still produced `excluded: 0` in every helm-controller log line, meaning no resources were being matched. The CRD schema for `target` documents the `group` field as working together with `kind` to unambiguously identify resources. For cluster-scoped resources outside the core API group (such as `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` in `admissionregistration.k8s.io`), the matcher appears to require the group to resolve the target correctly.

## Change

```yaml
# before
- paths: []
  target:
    kind: ValidatingWebhookConfiguration
    name: istio-validator-istio-system

# after
- paths: []
  target:
    group: admissionregistration.k8s.io
    kind: ValidatingWebhookConfiguration
    name: istio-validator-istio-system
```

Applied to all three webhook resources: `istiod-default-validator`, `istio-validator-istio-system`, and `istio-sidecar-injector`.