### PR TITLE
fix(istiod): switch drift detection to warn mode

### DIFF
--- a/infrastructure/controllers/istio.yaml
+++ b/infrastructure/controllers/istio.yaml
@@ -18,15 +18,12 @@ metadata:
 spec:
   interval: 1h
   driftDetection:
-    mode: enabled
-    ignore:
-      # istiod writes its CA bundle into this webhook at runtime. Excluding the
-      # entire resource prevents the permanent correcting-drift loop.
-      - paths: []
-        target:
-          group: admissionregistration.k8s.io
-          kind: ValidatingWebhookConfiguration
-          name: istiod-default-validator
+    # warn instead of enabled: istiod writes its CA bundle into the
+    # ValidatingWebhookConfiguration at runtime. The ignore rule target
+    # matcher does not resolve admissionregistration.k8s.io resources
+    # correctly in helm-controller v1.5.x, causing a permanent correction
+    # loop. warn mode retains drift visibility without attempting correction.
+    mode: warn
   dependsOn:
     - name: cilium
       namespace: flux-system
@@ -58,21 +55,8 @@ metadata:
 spec:
   interval: 1h
   driftDetection:
-    mode: enabled
-    ignore:
-      # istiod writes its CA bundle into all webhook configurations it owns at
-      # runtime. Excluding these resources entirely from drift detection prevents
-      # the permanent correcting-drift loop caused by the caBundle field.
-      - paths: []
-        target:
-          group: admissionregistration.k8s.io
-          kind: ValidatingWebhookConfiguration
-          name: istio-validator-istio-system
-      - paths: []
-        target:
-          group: admissionregistration.k8s.io
-          kind: MutatingWebhookConfiguration
-          name: istio-sidecar-injector
+    # warn instead of enabled: same reason as istio-base above.
+    mode: warn
   targetNamespace: istio-system
   dependsOn:
     - name: istio-base


### PR DESCRIPTION
## Summary

Switches `istio-base` and `istiod` from `driftDetection.mode: enabled` to `mode: warn`.

## Root cause

istiod writes its CA certificate bundle into three webhook configurations at runtime (`istiod-default-validator`, `istio-validator-istio-system`, `istio-sidecar-injector`). With `mode: enabled`, Flux detects this as drift and patches the fields back to the chart's static values. istiod restores them within one second, creating a permanent correction loop.

Multiple PRs (#123–#127) attempted to use `driftDetection.ignore` rules with path-based exclusions, full-resource exclusions, and explicit API group targeting. In every case, `helm-controller v1.5.x` logged `excluded: 0` — the ignore rule target matcher does not resolve `admissionregistration.k8s.io` resources from the SSA diff result regardless of how `group`, `kind`, `name`, or `paths` are specified.

## Fix

`mode: warn` tells Flux to detect drift and emit `DriftDetected` warning events but not attempt any correction. The HelmReleases will report `Ready: True` and the correction loop stops. All other resources in both releases (CRDs, ConfigMaps, RBAC, Deployments, Services) remain visible for drift auditing via events.

## What is lost

Automatic correction of out-of-band changes to non-webhook resources in `istio-base` and `istiod`. This is an acceptable trade-off; the Istio control plane is self-healing for its own resources, and the CA bundle scenario is the only known runtime-mutation case.