### PR TITLE
fix(prometheus): allow API server to reach admission webhook; use warn drift mode

### DIFF
--- a/apps/base/prometheus/helmrelease.yaml
+++ b/apps/base/prometheus/helmrelease.yaml
@@ -7,7 +7,12 @@ metadata:
 spec:
   interval: 1h
   driftDetection:
-    mode: enabled
+    # warn instead of enabled: cert-manager injects its CA bundle into
+    # the observability-kube-prometh-admission webhook configurations at
+    # runtime. With mode: enabled, Flux corrects the caBundle → cert-manager
+    # re-injects → permanent correction loop, identical to the istiod case
+    # (fixed in PR #128). warn retains drift visibility without correcting.
+    mode: warn
   targetNamespace: observability
   dependsOn:
     - name: openebs

--- a/apps/base/prometheus/netpol.yaml
+++ b/apps/base/prometheus/netpol.yaml
@@ -157,6 +157,33 @@ spec:
       ports:
         - port: 9090
 ---
+# The Kubernetes API server calls the Prometheus Operator admission webhook on
+# port 443 when creating or updating PrometheusRule and AlertmanagerConfig
+# resources. The API server has no pod or namespace label to select against,
+# so no `from` selector is used — any source reaching port 443 is allowed.
+# Without this rule the default-deny policy blocks the webhook, causing each
+# admission call to time out at 30 s (failurePolicy: Ignore). With 35+
+# PrometheusRules in the inventory, that adds 35 min to every Flux drift
+# detection pass, preventing observedGeneration from being set and blocking
+# all downstream HelmReleases that depend on kube-prometheus-stack.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-operator-allow-webhook-ingress
+  namespace: observability
+spec:
+  podSelector:
+    matchLabels:
+      app: kube-prometheus-stack-operator
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        # Service port 443 → container port 10250 (named "https").
+        # NetworkPolicy is enforced at the pod level, so the container port
+        # (10250) must be used here, not the service-level port (443).
+        - port: 10250
+---
 # Falcosidekick (in the falco namespace) ships structured alert JSON to Loki on
 # port 3100. The default-deny above blocks all cross-namespace ingress, so this
 # explicit rule is required for alert delivery to work.


### PR DESCRIPTION
## Summary

- **NetworkPolicy**: Add `prometheus-operator-allow-webhook-ingress` in the `observability` namespace allowing all sources to reach the Prometheus Operator on container port 10250. The API server calls this webhook when creating or updating `PrometheusRule` and `AlertmanagerConfig` resources. The existing `default-deny` policy blocked the API server (which has no pod/namespace label to match), causing each admission call to time out at the 30 s `timeoutSeconds` limit. With `failurePolicy: Ignore`, Kubernetes proceeds after each timeout — but with 35+ PrometheusRules in the inventory, every Flux drift detection pass spent ~35 minutes silently waiting on timeouts, preventing `observedGeneration` from being set and blocking all downstream HelmReleases (grafana, loki, tempo, opentelemetry-collector, promtail).
- **Drift detection mode**: Change `kube-prometheus-stack` from `mode: enabled` to `mode: warn`. cert-manager injects its CA bundle into the `observability-kube-prometh-admission` webhook configurations at runtime. With `enabled`, Flux corrects the `caBundle` field, cert-manager re-injects it, and the cycle repeats — the same correction loop fixed for istiod in PR #128.

## Root cause detail

The NetworkPolicy port in the initial live fix attempt was 443 (the service port). NetworkPolicies are enforced at the pod level; the correct port is 10250 (the container's `https` named port, which is what the service `targetPort: https` resolves to).

## Test plan

- [ ] Verify `kube-prometheus-stack` HelmRelease reaches `Ready: True` with `observedGeneration` matching `generation` quickly (under 2 min) on next reconciliation
- [ ] Verify `grafana`, `loki`, `tempo`, `opentelemetry-collector`, `promtail` unblock and reach `Ready: True`
- [ ] Verify `apps` kustomization reaches `Ready: True`
- [ ] Verify no `correcting cluster drift` loop for `kube-prometheus-stack`