### PR TITLE
fix: rightsize resource limits based on observed usage

### DIFF
--- a/apps/base/prometheus/helmrelease.yaml
+++ b/apps/base/prometheus/helmrelease.yaml
@@ -227,7 +227,7 @@ spec:
             memory: 256Mi
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 1Gi
         # Pick up ServiceMonitors from all namespaces so Cilium's
         # operator-emitted ServiceMonitors (in kube-system) are scraped.
         serviceMonitorSelectorNilUsesHelmValues: false

--- a/infrastructure/controllers/falco.yaml
+++ b/infrastructure/controllers/falco.yaml
@@ -86,8 +86,8 @@ spec:
         cpu: 100m
         memory: 256Mi
       limits:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 200m
+        memory: 256Mi
 
     # ── Falcosidekick — alert routing to Loki ────────────────────────────────────
     # Falco's native outputs are stdout/file/gRPC. Falcosidekick is the official

--- a/infrastructure/controllers/kyverno.yaml
+++ b/infrastructure/controllers/kyverno.yaml
@@ -59,8 +59,8 @@ spec:
           cpu: 100m
           memory: 256Mi
         limits:
-          cpu: 500m
-          memory: 512Mi
+          cpu: 150m
+          memory: 192Mi
     backgroundController:
       replicas: 1
       extraArgs:
@@ -70,8 +70,8 @@ spec:
           cpu: 100m
           memory: 128Mi
         limits:
-          cpu: 250m
-          memory: 256Mi
+          cpu: 100m
+          memory: 128Mi
     cleanupController:
       replicas: 1
       extraArgs:
@@ -81,8 +81,8 @@ spec:
           cpu: 100m
           memory: 128Mi
         limits:
-          cpu: 250m
-          memory: 256Mi
+          cpu: 100m
+          memory: 128Mi
     reportsController:
       replicas: 1
       extraArgs:
@@ -92,8 +92,8 @@ spec:
           cpu: 100m
           memory: 128Mi
         limits:
-          cpu: 250m
-          memory: 256Mi
+          cpu: 100m
+          memory: 128Mi
 
     # Globally exclude system and infrastructure namespaces at the webhook level.
     # Kyverno will not receive admission events for these at all, which is more

--- a/infrastructure/controllers/tetragon.yaml
+++ b/infrastructure/controllers/tetragon.yaml
@@ -71,8 +71,8 @@ spec:
           cpu: 100m
           memory: 256Mi
         limits:
-          cpu: 500m
-          memory: 512Mi
+          cpu: 100m
+          memory: 256Mi
     # export.resources controls the export-stdout sidecar container (chart key is
     # top-level, separate from tetragon.resources which covers the main agent).
     # Without this the sidecar has no limits and fails the require-resource-limits


### PR DESCRIPTION
## Summary

- **Prometheus** memory limit raised 512Mi → 1Gi; was at 86% utilization and at risk of OOM restarts
- **Falco** limits reduced CPU 500m → 200m, memory 512Mi → 256Mi; actual steady-state is ~55m CPU / ~125Mi RAM
- **Tetragon** limits reduced CPU 500m → 100m, memory 512Mi → 256Mi; actual steady-state is ~8m CPU / ~112Mi RAM
- **Kyverno admission** limits reduced CPU 500m → 150m, memory 512Mi → 192Mi; actual is ~16m CPU / ~65Mi RAM
- **Kyverno background/cleanup/reports** limits reduced CPU 250m → 100m, memory 256Mi → 128Mi; actual is 3–4m CPU / 27–57Mi RAM

## Rationale

All limits were set to Helm chart defaults and were over-provisioned by 3–8x versus observed usage. Over-provisioned limits distort the scheduler's view of node capacity and produce inaccurate HPA and resource pressure signals. Requests are unchanged; only limits are adjusted.

## Test plan

- [ ] Flux reconciles all four HelmReleases without error after merge
- [ ] Prometheus pod does not OOMKill under normal scrape load
- [ ] Falco, Tetragon, and Kyverno pods remain Running with no CrashLoopBackOff
- [ ] `kubectl top pods -A` shows all components well within new limits