### PR TITLE
fix: remove stale envoy-gateway HelmRepository

### DIFF
--- a/infrastructure/controllers/repositories.yaml
+++ b/infrastructure/controllers/repositories.yaml
@@ -59,16 +59,6 @@ spec:
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
-  name: envoy-gateway
-  namespace: flux-system
-spec:
-  interval: 24h
-  type: oci
-  url: oci://docker.io/envoyproxy
----
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
   name: kyverno
   namespace: flux-system
 spec:

--- a/versions.env
+++ b/versions.env
@@ -4,7 +4,6 @@
 # Keep in sync with the chart version constraints in infrastructure/controllers/:
 #   cilium.yaml        → CILIUM_VERSION
 #   istio.yaml         → ISTIO_VERSION
-#   envoy-gateway.yaml → ENVOY_GATEWAY_VERSION
 CILIUM_VERSION=1.19.5
 ISTIO_VERSION=1.30.2
 CONTOUR_VERSION=v1.33.5


### PR DESCRIPTION
## Summary

- Removed the `envoy-gateway` OCI HelmRepository from `infrastructure/controllers/repositories.yaml`
- Removed stale comment referencing `ENVOY_GATEWAY_VERSION` from `versions.env`

## Rationale

The `envoy-gateway` HelmRepository pointed to `oci://docker.io/envoyproxy` but had no associated HelmRelease consuming it. Flux source-controller never resolved it, leaving it with empty status in `flux get all -A`. It is dead configuration.

## Test plan

- [ ] After merge, `flux get helmrepositories -A` no longer shows `envoy-gateway`
- [ ] `infrastructure-controllers` kustomization reconciles successfully
- [ ] No other HelmRelease references the `envoy-gateway` repository