### PR TITLE
docs: update versions, add Day-2 ops guide, Strunk & White rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ FluxCD GitOps cluster for KinD — multi-node, Cilium CNI with kube-proxy replac
 | [Istio Basic Reference](docs/ISTIO_basic_notes.md) | Day-to-day Istio administration commands |
 | [Istio Advanced Reference](docs/ISTIO_advanced_notes.md) | mTLS enforcement, authorization policy, tracing configuration |
 | [iperf3 Network Testing](docs/iperf3.md) | TCP bandwidth measurement through the nginx nodeport-proxy stream layer — network path and test procedures |
+| [Day-2 Operations Guide](docs/day2-operations.md) | Daily cluster health checks, Renovate PR workflow, Kubescape score review, and secret rotation procedures |
 
 ## Repository Structure
 
@@ -118,7 +119,7 @@ homelab-gitops-k8s-2026/
 │           └── kustomization.yaml # Active: prometheus, grafana, istio, kyverno, loki, promtail, demo, tempo, opentelemetry, boinc, contour
 │
 └── scripts/
-    ├── setup-fluxcd-gitops-kind-multinode.sh  # Full 9-step cluster bootstrap
+    ├── setup-fluxcd-gitops-kind-multinode.sh  # Full 10-step cluster bootstrap
     ├── destroy.sh                             # Tear down cluster and Flux
     ├── set-flux-branch.sh                     # Update Flux GitRepository branch patch
     ├── kind-pre-loader-for-images.sh          # Standalone image pre-loader for KinD nodes
@@ -191,27 +192,27 @@ The "Chart Version" column is the Helm chart release version. The "App Version" 
 | Cilium CNI | cilium/cilium | 1.19.5 | v1.19.5 | kube-system | |
 | Hubble Relay | (bundled with Cilium) | 1.19.5 | v1.19.5 | kube-system | |
 | Hubble UI | (bundled with Cilium) | — | 0.13.1 | kube-system | Disabled by default; enable via `hubble.ui.enabled: true` in `cilium.yaml` |
-| cert-manager | cert-manager/cert-manager | v1.20.2 | v1.20.2 | cert-manager | |
-| OpenEBS localpv | openebs/openebs | 4.5.0 | 4.5.0 | openebs | |
-| istio-base | istio/base | 1.30.1 | 1.30.1 | istio-system | |
-| istiod | istio/istiod | 1.30.1 | 1.30.1 | istio-system | |
+| cert-manager | cert-manager/cert-manager | v1.20.3 | v1.20.3 | cert-manager | |
+| OpenEBS localpv | openebs/openebs | 4.5.1 | 4.5.1 | openebs | |
+| istio-base | istio/base | 1.30.2 | 1.30.2 | istio-system | |
+| istiod | istio/istiod | 1.30.2 | 1.30.2 | istio-system | |
 | Contour | projectcontour/contour | 0.6.0 | 1.33.5 | contour | Sole HTTP ingress controller; streams xDS to its Envoy DaemonSet over gRPC port 8001 |
 | Contour Envoy data-plane | (bundled with Contour chart) | 0.6.0 | v1.35.10 | contour | DaemonSet data plane; receives xDS from the Contour controller and routes live HTTP traffic |
 | Metrics Server | metrics-server/metrics-server | 3.13.1 | 0.8.1 | metrics-server | Powers `kubectl top` and HPA; `--kubelet-insecure-tls` required for KinD |
-| kube-prometheus-stack | prometheus-community/kube-prometheus-stack | 86.2.3 | v0.91.0 (operator) | observability | |
+| kube-prometheus-stack | prometheus-community/kube-prometheus-stack | 87.2.1 | v0.92.0 (operator) | observability | |
 | Grafana | grafana/grafana | 10.5.15 | 12.3.1 | observability | |
 | Loki | grafana/loki | 7.0.0 | 3.6.7 | observability | |
 | Promtail | grafana/promtail | 6.17.1 | 3.5.1 | observability | |
 | Grafana Tempo | grafana/tempo | 1.24.4 | 2.9.0 | observability | Single-binary mode; trace backend for the OTel pipeline |
-| OpenTelemetry Collector | open-telemetry/opentelemetry-collector | 0.158.2 | 0.153.0 | observability | Contrib distribution; OTLP ingress → Tempo export; Istio sidecar disabled |
+| OpenTelemetry Collector | open-telemetry/opentelemetry-collector | 0.159.0 | 0.154.0 | observability | Contrib distribution; OTLP ingress → Tempo export; Istio sidecar disabled |
 | Tetragon | cilium/tetragon | 1.7.0 | 1.7.0 | tetragon | |
 | Kyverno | kyverno/kyverno | 3.8.1 | v1.18.1 | kyverno | |
 | Kubescape | kubescape/kubescape-operator | 1.40.2 | v4.0.8 | kubescape | NSA + MITRE continuous scan; vulnerability scan disabled for KinD |
 | Falco + Falcosidekick | falcosecurity/falco | 9.1.0 | 0.44.1 / 2.32.0 | falco | |
-| Trivy Operator | aquasecurity/trivy-operator | 0.33.1 | 0.31.1 | trivy-system | Image CVE scanning — VulnerabilityReport CRDs + Prometheus metrics; `ignoreUnfixed: true` |
+| Trivy Operator | aquasecurity/trivy-operator | 0.33.2 | 0.31.2 | trivy-system | Image CVE scanning — VulnerabilityReport CRDs + Prometheus metrics; `ignoreUnfixed: true` |
 | demo (httpbin) | kennethreitz/httpbin | — | @sha256:599fe5… | demo | No versioned tags published; pinned by digest |
 | iperf3 server | networkstatic/iperf3 | — | multiarch | iperf3 | TCP bandwidth measurement via nginx stream block; direct path, no ingress controller |
-| BOINC | boinc/client | — | arm64v8 | boinc | Voluntary compute — Rosetta@Home + Einstein@Home; capped at 1 CPU core for thermal management |
+| BOINC | boinc/client | — | arm64v8 | boinc | Voluntary compute — Rosetta@Home + Einstein@Home; capped at 950m CPU for thermal management |
 | Renovate | renovatebot/github-action | — | — | — | Automated dependency PRs for Helm charts, images, GitHub Actions, and CI tool pins |
 | Gitleaks | gitleaks/gitleaks | — | — | — | Secret scanning on every PR — detects accidentally committed credentials before merge |
 
@@ -238,18 +239,18 @@ The versions below were validated together. When upgrading a component, verify c
 | Kubernetes (KinD node) | — | v1.36.1 | `K8S_VER` in `versions.env` |
 | Flux CD | — | v2.8.8 | `flux bootstrap github` — update by re-running bootstrap with a newer CLI |
 | Cilium | 1.19.5 | v1.19.5 | `cilium.yaml` chart constraint (`1.19.x`) + `versions.env` |
-| Istio | 1.30.1 | 1.30.1 | `istio.yaml` chart constraint (`1.30.x`) + `versions.env` |
+| Istio | 1.30.2 | 1.30.2 | `istio.yaml` chart constraint (`1.30.x`) + `versions.env` |
 | Contour | 0.6.0 | 1.33.5 | `contour.yaml` chart constraint (`0.x`); `CONTOUR_VERSION` in `versions.env` (informational — Contour is installed by Flux, not the bootstrap script) |
-| kube-prometheus-stack | 86.2.3 | v0.91.0 (operator) | `prometheus/helmrelease.yaml` chart constraint (`86.x`) |
+| kube-prometheus-stack | 87.2.1 | v0.92.0 (operator) | `prometheus/helmrelease.yaml` chart constraint (`87.x`) |
 | Loki | 7.0.0 | 3.6.7 | `loki/helmrelease.yaml` chart constraint (`7.x`) |
 | Grafana | 10.5.15 | 12.3.1 | `grafana/helmrelease.yaml` chart constraint (`10.x`) |
 | Grafana Tempo | 1.24.4 | 2.9.0 | `tempo/helmrelease.yaml` chart constraint (`1.x`) |
-| OpenTelemetry Collector | 0.158.2 | 0.153.0 | `opentelemetry/helmrelease.yaml` chart constraint (`0.158.x`) |
+| OpenTelemetry Collector | 0.159.0 | 0.154.0 | `opentelemetry/helmrelease.yaml` chart constraint (`0.159.x`) |
 | Kyverno | 3.8.1 | v1.18.1 | `kyverno.yaml` chart constraint (`3.x`) |
 | Kubescape | 1.40.2 | v4.0.8 | `kubescape.yaml` chart constraint (`1.40.x`) |
 | Falco | 9.1.0 | 0.44.1 | `falco.yaml` chart constraint (`9.x`) |
 | Tetragon | 1.7.0 | 1.7.0 | `tetragon.yaml` chart constraint (`1.7.x`) |
-| Trivy Operator | 0.33.1 | 0.31.1 | `trivy.yaml` chart constraint (`0.x`) |
+| Trivy Operator | 0.33.2 | 0.31.2 | `trivy.yaml` chart constraint (`0.x`) |
 
 All version pins shared between the Makefile and setup script are sourced from `versions.env` at the repository root. Updating them there propagates the change to both consumers.
 
@@ -284,6 +285,10 @@ All version pins shared between the Makefile and setup script are sourced from `
 **Five-layer runtime security model** — Kyverno (admission control) validates pods before they start and audits misconfigurations. Tetragon (eBPF enforcement) can terminate processes and block network connections at the syscall level. Falco (behavioral detection) continuously audits running containers and issues alerts on anomalous activity — shell spawning, sensitive file reads, credential exposure — routing them to Loki via Falcosidekick. Kubescape (compliance scanning) continuously audits the cluster's actual running state against NSA and MITRE ATT&CK frameworks and surfaces configuration drift. Trivy Operator (image CVE scanning) continuously scans every running container image and produces `VulnerabilityReport` CRDs with Prometheus metrics. The five tools are complementary: Kyverno prevents bad configuration from entering, Tetragon stops active exploitation, Falco logs suspicious activity for forensic review, Kubescape measures posture against industry frameworks, and Trivy surfaces known CVEs in the images actually running in the cluster.
 
 **Gitleaks runs on every PR** — The `validate.yaml` CI workflow runs Gitleaks as its first step (before kustomize build or Kyverno tests) to detect accidentally committed credentials, API keys, and private key material. The version pin is tracked by Renovate via a custom regex manager so it stays current automatically.
+
+**Resource limits are sized from observed usage with a safety margin** — CPU and memory limits are not arbitrary defaults. Each component's limits were set after reviewing `kubectl top pods` output over representative workloads and adding a margin for bursts. Prometheus requires 1 Gi memory because it holds an in-memory query engine and multiple scrape targets; its observed usage of ~440 Mi makes OOM a real risk at 512 Mi. Falco is capped at 200m CPU (observed ~55m) and Tetragon at 100m CPU (observed ~8m); these margins prevent thermal spikes on the passively cooled M5 host without over-allocating scheduler headroom. Kyverno's admission controller is capped at 150m CPU and 192 Mi memory — tight enough to free capacity for workloads, loose enough to handle bursty webhook traffic. All limits were updated in PR #136 based on live cluster measurements.
+
+**Grafana requires a stable `secret_key` across restarts** — Grafana encrypts datasource credentials and signs user sessions using a secret key stored in `GF_SECURITY_SECRET_KEY`. Without a stable, pre-created key, every pod restart re-generates a random key, which invalidates existing sessions and corrupts stored datasource passwords. The bootstrap script (step 10) pre-creates the `grafana-secret-key` Kubernetes Secret in the `observability` namespace before Flux reconciles. The Grafana HelmRelease reads this Secret via `envValueFrom`. If the Secret is absent when Grafana first installs, Kubernetes rejects the pod and the HelmRelease enters a failed state. Recreate it with: `kubectl create secret generic grafana-secret-key --namespace observability --from-literal=secret-key="$(openssl rand -base64 32)"`.
 
 **PrometheusRules in a separate Flux Kustomization** — Custom `PrometheusRule` CRDs (cluster health, GitOps health, certificate expiry, Falco critical events, Kyverno enforcement violations) cannot be bundled in the same Flux Kustomization as the kube-prometheus-stack HelmRelease that installs the CRD. Flux dry-runs all resources before applying any of them, so the CRD is never present when the dry-run runs — causing a deadlock that prevents the HelmRelease from applying too. The fix: a separate `monitoring-rules` Kustomization (`clusters/kind/monitoring-rules.yaml`) with `dependsOn: apps`. Because `apps` has `wait: true`, Flux marks it healthy only after kube-prometheus-stack is fully running and the CRD is registered.
 
@@ -339,6 +344,7 @@ What it does:
 7. Runs `flux bootstrap github` to push Flux manifests and start reconciliation
 8. Creates the SOPS age key secret in `flux-system` if the key file exists
 9. Creates the `github-token` secret in `flux-system` — reuses the token from `gh auth` (already has `repo` scope from step 7) so the Flux notification controller can post commit status checks back to GitHub
+10. Creates the `grafana-secret-key` Secret in the `observability` namespace — a randomly generated 32-byte key that Grafana uses to encrypt datasource credentials and sign sessions. Pre-creating this Secret before Flux reconciles prevents a failed first install: the Grafana HelmRelease references this Secret via `envValueFrom`, and Kubernetes rejects the pod if the Secret is absent
 
 ### Estimated Time
 

--- a/docs/ISTIO_advanced_notes.md
+++ b/docs/ISTIO_advanced_notes.md
@@ -1,6 +1,6 @@
 # Istio — Advanced Administration Reference
 
-Cluster: `flux-kind` · Istio 1.30 · Cilium CNI with `socketLB.hostNamespaceOnly: true`
+Cluster: `flux-kind` · Istio 1.30.2 · Cilium CNI with `socketLB.hostNamespaceOnly: true`
 
 ---
 

--- a/docs/ISTIO_basic_notes.md
+++ b/docs/ISTIO_basic_notes.md
@@ -1,6 +1,6 @@
 # Istio — Daily Administration Reference
 
-Cluster: `flux-kind` · Istio 1.30 · istiod in `istio-system`
+Cluster: `flux-kind` · Istio 1.30.2 · istiod in `istio-system`
 
 ---
 

--- a/docs/boinc.md
+++ b/docs/boinc.md
@@ -49,7 +49,7 @@ Source file: [apps/base/boinc/netpol.yaml](../apps/base/boinc/netpol.yaml)
 
 ### CPU Limit and Thermal Management
 
-The DaemonSet is capped at `1000m` (1 CPU core out of 10 on the M5 chip). On the passively cooled MacBook Air M5, this keeps peak core temperatures below 65°C. Raising the limit above 1500m pushes cores to 74°C+, which is within Apple Silicon's safe operating range but above the thermal target for this cluster.
+The DaemonSet is capped at `950m` (0.95 CPU cores out of 10 on the M5 chip). On the passively cooled MacBook Air M5, this keeps peak core temperatures below 65°C. Raising the limit above 1500m pushes cores to 74°C+, which is within Apple Silicon's safe operating range but above the thermal target for this cluster.
 
 ---
 
@@ -159,11 +159,11 @@ The most common cause is an incorrect authenticator key in the Secret. Fix with 
 
 ### High CPU Temperatures
 
-BOINC uses its full limit (1000m) whenever work units are available. If temperatures are consistently above 65°C, lower the CPU limit in `apps/base/boinc/daemonset.yaml`:
+BOINC uses its full limit (950m) whenever work units are available. If temperatures are consistently above 65°C, lower the CPU limit in [apps/base/boinc/daemonset.yaml](../apps/base/boinc/daemonset.yaml):
 
 ```yaml
 limits:
-  cpu: 750m   # down from 1000m
+  cpu: 750m   # down from 950m
 ```
 
 Alternatively, set CPU usage preferences on the BOINC project website: account settings → computing preferences → "Use at most X% of CPU time".

--- a/docs/day2-operations.md
+++ b/docs/day2-operations.md
@@ -1,0 +1,291 @@
+# Day-2 Operations Guide
+
+Cluster: `flux-kind` · KinD 1.36.1 · 1 control-plane + 2 workers
+
+This guide covers the routine tasks an operator performs after the cluster is running. Bootstrap and initial setup are covered in the [README](../README.md). This document addresses ongoing operations: daily health checks, dependency updates via Renovate, security posture review with Kubescape, and secret rotation.
+
+---
+
+## Daily Health Check
+
+Run these commands each day the cluster is active. Proceed to per-technology sections in the [Troubleshooting Guide](troubleshooting-guide.md) only when a specific component requires investigation.
+
+```bash
+# 1. All Flux resources — every row must show READY: True
+flux get all -A
+
+# 2. Any pod not Running or Completed is a problem
+kubectl get pods -A | grep -v "Running\|Completed"
+
+# 3. Node resource usage — watch for sustained high CPU or memory pressure
+kubectl top nodes
+
+# 4. Confirm Grafana is reachable (302 = login redirect, indicates healthy stack)
+curl -s -o /dev/null -w "%{http_code}" -H "Host: grafana.local" http://localhost:8080/
+```
+
+Expected output: all Flux resources `READY: True`, no pods stuck, nodes show reasonable CPU and memory, Grafana returns `302`.
+
+### Reading the Grafana Health Dashboard
+
+Open `http://grafana.local:8080` and navigate to **Dashboards → Node Exporter Full**. Check:
+
+- **CPU busy** — should remain below 80% during idle periods; BOINC will push it higher during active compute, which is expected.
+- **Memory available** — a downward trend that does not recover indicates a memory leak; investigate `kubectl top pods -A --sort-by=memory`.
+- **Disk I/O** — Loki and Prometheus write continuously to PVCs; spikes are normal, but sustained high rates may indicate excessive log volume.
+
+### Reading Flux Reconciliation State
+
+```bash
+flux get all -A
+```
+
+| Status | Meaning |
+|--------|---------|
+| `READY: True` | The cluster matches the Git state for this resource. |
+| `READY: False` + `RECONCILING` | Flux is actively applying a change. Wait 30–60 seconds and re-check. |
+| `READY: False` + error message | A failure occurred. Read the message and consult the [Troubleshooting Guide](troubleshooting-guide.md). |
+
+A common cause of `READY: False` after a push is a transient network error fetching a Helm chart. Force a retry:
+
+```bash
+flux reconcile source git flux-system -n flux-system
+```
+
+---
+
+## Handling Renovate Pull Requests
+
+Renovate opens pull requests automatically when it detects newer versions of Helm charts, container images, GitHub Actions, and CLI tool pins.
+
+### Triage Workflow
+
+```bash
+# List all open Renovate PRs
+gh pr list --label "renovate"
+```
+
+For each open PR:
+
+1. **Read the PR description.** Renovate includes the changelog, the time since the new version was published, and the adoption rate among other users. A version published hours ago with low adoption warrants more caution than one published months ago with wide adoption.
+
+2. **Check CI.** The `validate` workflow must pass before merging. If CI fails on a Renovate PR, investigate the kustomize build or Kyverno test output — the new version may have introduced a breaking change.
+
+3. **Merge or defer.** Patch image updates and GitHub Actions updates are configured to automerge after CI passes. Flux minor updates (chart constraint bumps) require human review. Infrastructure pins (`CILIUM_VERSION`, `ISTIO_VERSION`, `K8S_VER`) require a cluster rebuild to take effect — plan accordingly.
+
+### After Merging
+
+Flux reconciles within one minute of the merge reaching `main`. Monitor:
+
+```bash
+watch -n 6 "flux get helmreleases -A"
+```
+
+If a chart upgrade fails, the HelmRelease enters a failed state with an error message. Force a retry after investigating:
+
+```bash
+flux reconcile helmrelease <name> -n flux-system
+```
+
+### Rolling Back a Bad Merge
+
+```bash
+# Find the merge commit
+git log --oneline -10
+
+# Revert it (creates a new commit — safe for a shared branch)
+git revert <merge-commit-sha>
+git push origin main
+
+# Force Flux to reconcile immediately
+flux reconcile source git flux-system -n flux-system
+```
+
+---
+
+## Reviewing Kubescape Security Scores
+
+Kubescape continuously scans the cluster against the NSA Kubernetes Hardening Guide and MITRE ATT&CK framework. Results are exposed as Prometheus metrics and visible in Grafana.
+
+### Grafana Dashboard
+
+Open `http://grafana.local:8080`, navigate to **Dashboards → Kubescape Security Posture**. The dashboard shows:
+
+- **Compliance score** — percentage of controls passing per framework. A declining score indicates a new workload or configuration that violates a control.
+- **Control failures by resource** — which specific Kubernetes resources are failing which controls.
+- **Historical trend** — whether the score is improving, stable, or declining over time.
+
+### CLI Review
+
+```bash
+# On-demand scan against the live cluster (NSA + MITRE)
+make test-kubescape
+
+# Or run directly for verbose output
+kubescape scan framework nsa,mitre \
+  --cluster-context "kind-flux-kind" \
+  --format pretty-printer \
+  --verbose
+```
+
+### Interpreting Findings
+
+Before investigating a finding, consult [docs/kubescape-security.md](kubescape-security.md). That document records findings that have been reviewed and formally accepted as intentional design decisions. If a finding is already listed there, no further action is required.
+
+For a new finding:
+
+1. Identify the affected resource:
+   ```bash
+   kubectl get workloadconfigurationscans -A | grep <control-id>
+   ```
+2. Determine whether the finding represents a real risk or an accepted trade-off for this environment.
+3. If accepted: add an entry to [docs/kubescape-security.md](kubescape-security.md) with the control ID, the affected resource, and the rationale.
+4. If remediated: fix the configuration in the appropriate manifest and open a PR.
+
+```bash
+# View scan results as CRDs
+kubectl get configurationscansummaries -A
+kubectl get workloadconfigurationscans -A
+```
+
+---
+
+## Rotating Secrets
+
+### Grafana Admin Password
+
+The Grafana admin password is stored in `apps/base/grafana/admin-secret.yaml` (SOPS-encrypted) and sourced into the HelmRelease via `valuesFrom`. To change it:
+
+```bash
+# Open the decrypted YAML in $EDITOR — re-encrypts on save
+sops apps/base/grafana/admin-secret.yaml
+```
+
+Edit the `admin-password` value, save, and quit. Commit and push. Flux will apply the updated Secret on the next reconcile. Grafana picks up the new password automatically on pod restart:
+
+```bash
+kubectl rollout restart deployment -n observability observability-grafana
+```
+
+### Grafana `secret_key`
+
+The `grafana-secret-key` Secret stores the key Grafana uses to encrypt datasource credentials and sign user sessions. Rotating this key invalidates all active browser sessions and forces a re-entry of datasource passwords. Perform rotation only when required (e.g., suspected key exposure).
+
+```bash
+# Generate a new key and apply it to the running cluster
+kubectl create secret generic grafana-secret-key \
+  --namespace observability \
+  --from-literal=secret-key="$(openssl rand -base64 32)" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Restart Grafana to load the new key
+kubectl rollout restart deployment -n observability observability-grafana
+```
+
+Note: The bootstrap script recreates this Secret automatically on every `make bootstrap`. Manual rotation is needed only on a running cluster.
+
+### SOPS Age Key
+
+The SOPS age private key encrypts every Secret in this repository. Rotate it only in case of suspected compromise.
+
+1. Generate a new key pair:
+   ```bash
+   age-keygen -o ~/.config/sops/age/keys-new.txt
+   ```
+2. Update `.sops.yaml` with the new public key.
+3. Re-encrypt every `*-secret.yaml` file:
+   ```bash
+   for f in $(find apps/base -name '*-secret.yaml'); do
+     sops --rotate --in-place "$f"
+   done
+   ```
+4. Load the new key into the cluster:
+   ```bash
+   make sops-load-key
+   ```
+5. Commit and push.
+
+### BOINC Project Credentials
+
+Project authenticator keys are stored in `apps/base/boinc/boinc-projects-secret.yaml` (SOPS-encrypted). To update:
+
+```bash
+sops apps/base/boinc/boinc-projects-secret.yaml
+```
+
+Edit the authenticator key for the affected project, save, commit, push, then restart the DaemonSet:
+
+```bash
+kubectl rollout restart daemonset/boinc -n boinc
+```
+
+---
+
+## Checking Cluster After Mac Wakes from Sleep
+
+Docker Desktop pauses its Linux VM when the Mac sleeps. Istio issues 24-hour workload certificates to each Envoy sidecar; if the VM is paused through the rotation window (~19 h), sidecars will present expired certificates until restarted.
+
+**Symptom:** Grafana dashboards show TLS errors (`CERTIFICATE_VERIFY_FAILED`).
+
+**Fix:**
+
+```bash
+kubectl rollout restart deployment statefulset -n observability
+kubectl rollout restart deployment -n demo
+```
+
+Allow ~60 seconds for pods to restart and istiod to issue fresh certificates. Verify:
+
+```bash
+istioctl proxy-config secret -n observability deploy/observability-grafana | grep default
+# VALID CERT should show: true
+```
+
+---
+
+## Verifying the Full Ingress Stack
+
+After any change to nginx, Contour, or the cluster network, verify the end-to-end path:
+
+```bash
+# HTTP ingress via Contour
+curl -s -o /dev/null -w "%{http_code}\n" -H "Host: grafana.local" http://localhost:8080/
+# Expected: 302
+
+curl -s -o /dev/null -w "%{http_code}\n" -H "Host: prometheus.local" http://localhost:8080/
+# Expected: 200
+
+curl -s -o /dev/null -w "%{http_code}\n" -H "Host: httpbin-contour.local" http://localhost:8080/get
+# Expected: 200
+
+# TCP path via nginx stream block (iperf3)
+iperf3 -4 -c localhost -p 32111 -t 10
+# Expected: ~700–800 Mbits/sec, 0 retransmits
+```
+
+---
+
+## Useful One-Liners
+
+```bash
+# Count vulnerability reports by severity
+kubectl get vulnerabilityreports -A -o json \
+  | jq '[.items[].report.summary] | {
+      critical: (map(.criticalCount) | add),
+      high:     (map(.highCount)     | add),
+      medium:   (map(.mediumCount)   | add)
+    }'
+
+# Show all non-zero Falco rule matches
+kubectl logs -n falco -l app.kubernetes.io/name=falco --tail=200 \
+  | grep -i 'Critical\|Error'
+
+# Show all BOINC active tasks
+POD=$(kubectl get pod -n boinc -l app=boinc -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n boinc $POD -- boinccmd --get_tasks
+
+# Force reconcile all HelmReleases (useful after a Flux upgrade)
+flux get helmreleases -n flux-system --no-header \
+  | awk '{print $1}' \
+  | xargs -I {} flux reconcile helmrelease {} -n flux-system
+```

--- a/docs/key_concepts.md
+++ b/docs/key_concepts.md
@@ -225,6 +225,8 @@ Findings that have been reviewed and accepted as intentional are recorded in `do
 
 Encrypted values appear as `ENC[AES256_GCM,data:...,type:str]` in the YAML file. Only the `data` and `stringData` fields are encrypted; `kind`, `metadata`, and `apiVersion` remain readable. Flux's `kustomize-controller` decrypts secrets in memory at reconcile time using a private key stored in the cluster as the `sops-age` secret.
 
+**Grafana also requires a non-SOPS bootstrap secret:** the `grafana-secret-key` in the `observability` namespace. Grafana uses this key to encrypt stored datasource credentials and sign user sessions. It is not committed to Git. The bootstrap script generates it with `openssl rand -base64 32` and creates it in the cluster before Flux reconciles. If this Secret is absent when Grafana first installs, Kubernetes rejects the pod because the `envValueFrom` reference is unresolvable. See [docs/sops-age-secrets.md](sops-age-secrets.md) for recovery instructions.
+
 See [docs/sops-age-secrets.md](sops-age-secrets.md) for the complete setup guide and day-to-day workflow.
 
 ---
@@ -238,7 +240,7 @@ This cluster participates in:
 - **Rosetta@Home** — protein structure prediction for medical research
 - **Einstein@Home** — gravitational wave and pulsar detection
 
-BOINC runs as a DaemonSet (one pod per node). It is capped at 1 CPU core to keep peak temperatures below 65°C on the passively cooled MacBook Air M5.
+BOINC runs as a DaemonSet (one pod per node). It is capped at 950m CPU (0.95 cores) to keep peak temperatures below 65°C on the passively cooled MacBook Air M5.
 
 See [docs/boinc.md](boinc.md) for operational details, status commands, and how to update project credentials.
 
@@ -298,12 +300,12 @@ kubectl get vulnerabilityreports -A
 
 | Tool | What It Captures | Chart Version | App Version |
 |------|-----------------|---------------|-------------|
-| **Prometheus** (`kube-prometheus-stack`) | Metrics — numbers over time (CPU %, request rate, error count) | 86.2.3 | v0.91.0 (operator) |
+| **Prometheus** (`kube-prometheus-stack`) | Metrics — numbers over time (CPU %, request rate, error count) | 87.2.1 | v0.92.0 (operator) |
 | **Grafana** | Dashboards — visual graphs and tables built from Prometheus and Loki data | 10.5.15 | 12.3.1 |
 | **Loki** | Logs — the text output of every container in the cluster | 7.0.0 | 3.6.7 |
 | **Promtail** | Log collector — a DaemonSet that reads log files on each node and ships them to Loki | 6.17.1 | 3.5.1 |
 | **Grafana Tempo** | Distributed traces — records the full path a request takes through multiple services | 1.24.4 | 2.9.0 |
-| **OpenTelemetry Collector** | Trace pipeline — receives OTLP trace spans from Istio Envoy sidecars and forwards them to Tempo | 0.158.2 | 0.153.0 |
+| **OpenTelemetry Collector** | Trace pipeline — receives OTLP trace spans from Istio Envoy sidecars and forwards them to Tempo | 0.159.0 | 0.154.0 |
 
 **How they connect:**
 

--- a/docs/post-quantum-readiness.md
+++ b/docs/post-quantum-readiness.md
@@ -78,7 +78,7 @@ sidecar-injected pod. Certificates rotate every 24 hours by default.
 
 ### 3. cert-manager (Installed, No Active Issuers)
 
-**Config:** `infrastructure/controllers/cert-manager.yaml` — version v1.20.2
+**Config:** `infrastructure/controllers/cert-manager.yaml` — version v1.20.3
 
 cert-manager is installed as an Istio dependency. No `Certificate`, `Issuer`, or
 `ClusterIssuer` CRDs are deployed — it is not currently issuing any certificates.

--- a/docs/sops-age-secrets.md
+++ b/docs/sops-age-secrets.md
@@ -218,7 +218,7 @@ After `make destroy`, the cluster is gone and the `sops-age` secret is lost with
 
 ```bash
 make destroy
-make bootstrap        # step 9/10 re-creates sops-age automatically
+make bootstrap        # step 8/10 re-creates sops-age automatically
 flux get all -A       # watch reconciliation — secrets decrypt on first sync
 ```
 
@@ -255,6 +255,33 @@ The `decryption:` block in `clusters/kind/apps.yaml`:
 ```
 
 Only the `apps` Kustomization carries this block because that is the layer where encrypted secrets currently reside. If encrypted secrets are added to the `infrastructure-configs` layer in the future, the same block must be added to `clusters/kind/infrastructure-configs.yaml`.
+
+---
+
+## Grafana `secret_key` — A Related Bootstrap Secret
+
+The `grafana-secret-key` Secret is not managed by SOPS. It is not committed to Git. The bootstrap script (step 10 of 10) creates it directly in the `observability` namespace using `openssl rand -base64 32`.
+
+This Secret is separate from the SOPS-managed `grafana-admin-secret`. Its purpose is different: Grafana uses `GF_SECURITY_SECRET_KEY` to encrypt stored datasource passwords and sign browser sessions. Without a stable value, every pod restart generates a new key, which corrupts stored datasource credentials and forces all users to log in again.
+
+**What happens if it is missing:**
+
+If `grafana-secret-key` does not exist in the `observability` namespace when the Grafana HelmRelease first installs, Kubernetes rejects the pod because the `envValueFrom` reference cannot be resolved. The HelmRelease enters a failed state and Grafana does not start.
+
+**How to recreate it on a running cluster:**
+
+```bash
+kubectl create secret generic grafana-secret-key \
+  --namespace observability \
+  --from-literal=secret-key="$(openssl rand -base64 32)" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Force Grafana to pick it up
+flux suspend helmrelease grafana -n flux-system
+flux resume helmrelease grafana -n flux-system
+```
+
+**After a cluster rebuild:** The bootstrap script recreates this Secret automatically. No manual step is required after `make bootstrap`.
 
 ---
 

--- a/docs/trivy.md
+++ b/docs/trivy.md
@@ -1,6 +1,6 @@
 # Trivy Operator — Vulnerability & Security Scanning
 
-Cluster: `flux-kind` · Operator namespace: `trivy-system` · Chart: `0.33.1` · App: `0.31.1` · Config: `infrastructure/controllers/trivy.yaml`
+Cluster: `flux-kind` · Operator namespace: `trivy-system` · Chart: `0.33.2` · App: `0.31.2` · Config: `infrastructure/controllers/trivy.yaml`
 
 ---
 

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -1,7 +1,7 @@
 # Troubleshooting Guide
 
 Cluster: `flux-kind` · KinD 1.36.1 · 1 control-plane + 2 workers
-Stack: Flux CD · Cilium 1.19 · Hubble · cert-manager 1.20 · OpenEBS 4.x · Istio 1.30 (mesh only) · Contour 1.33 · Metrics Server 3.x · Tetragon 1.7 · Kyverno 3 · Kubescape 1.40 · Falco 9 · Trivy Operator 0.x · kube-prometheus-stack 86 · Grafana 10 (app 12) · Grafana Tempo 1 · OpenTelemetry Collector 0 · BOINC · SOPS + Age · iperf3
+Stack: Flux CD · Cilium 1.19 · Hubble · cert-manager 1.20 · OpenEBS 4.x · Istio 1.30 (mesh only) · Contour 1.33 · Metrics Server 3.x · Tetragon 1.7 · Kyverno 3 · Kubescape 1.40 · Falco 9 · Trivy Operator 0.x · kube-prometheus-stack 87 · Grafana 10 (app 12) · Grafana Tempo 1 · OpenTelemetry Collector 0 · BOINC · SOPS + Age · iperf3
 
 ---
 
@@ -1005,7 +1005,7 @@ kubectl get pods -n observability -l app.kubernetes.io/name=kube-prometheus-stac
 
 ### Prometheus UI
 
-No port-forward required via Gateway API:
+No port-forward required via Contour HTTPProxy:
 
 ```text
 http://prometheus.local:8080
@@ -1062,7 +1062,7 @@ kubectl logs -n observability -l app.kubernetes.io/name=prometheus --container=p
 
 ### Grafana UI
 
-No port-forward required via Gateway API:
+No port-forward required via Contour HTTPProxy:
 
 ```text
 http://grafana.local:8080
@@ -1081,6 +1081,21 @@ kubectl port-forward -n observability svc/observability-grafana 3000:80
 
 ```bash
 kubectl get pods -n observability -l app.kubernetes.io/name=grafana
+```
+
+### Verify the grafana-secret-key Secret Exists
+
+The Grafana pod will not start if this Secret is missing from the `observability` namespace:
+
+```bash
+kubectl get secret grafana-secret-key -n observability
+# If missing, recreate it:
+kubectl create secret generic grafana-secret-key \
+  --namespace observability \
+  --from-literal=secret-key="$(openssl rand -base64 32)" \
+  --dry-run=client -o yaml | kubectl apply -f -
+# Then force a clean install:
+flux suspend helmrelease grafana -n flux-system && flux resume helmrelease grafana -n flux-system
 ```
 
 ### Verify Dashboards Loaded
@@ -1125,7 +1140,7 @@ kubectl logs -n observability deploy/observability-grafana -c grafana | tail -50
 
 ## 16. Flux GitHub Notifications
 
-Flux posts commit status checks to GitHub via the notification controller. The Provider and Alerts live in `apps/base/notifications/`; the `github-token` secret is created by the bootstrap script (step 9).
+Flux posts commit status checks to GitHub via the notification controller. The Provider and Alerts live in `apps/base/notifications/`; the `github-token` secret is created by the bootstrap script (step 9 of 10).
 
 ### Check Notification Controller Health
 

--- a/images/architecture.svg
+++ b/images/architecture.svg
@@ -155,7 +155,7 @@
   <rect x="55" y="550" width="136" height="54" rx="6" fill="#EFF6FF" stroke="#1D4ED8" stroke-width="1.25"/>
   <text x="123" y="568" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="11" font-weight="700" fill="#1D4ED8">Prometheus</text>
   <text x="123" y="583" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#475569">kube-prometheus-stack</text>
-  <text x="123" y="597" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">86.x · dependsOn: openebs</text>
+  <text x="123" y="597" text-anchor="middle" font-family="system-ui, -apple-system, Arial, sans-serif" font-size="9" fill="#94A3B8">87.x · dependsOn: openebs</text>
 
   <!-- AlertManager chip -->
   <rect x="203" y="550" width="132" height="54" rx="6" fill="#EFF6FF" stroke="#1D4ED8" stroke-width="1.25"/>

--- a/images/technology-map.svg
+++ b/images/technology-map.svg
@@ -83,7 +83,7 @@
 
   <rect x="520" y="209" width="160" height="46" rx="8" fill="white" stroke="#0891B2" stroke-width="1.5"/>
   <text x="600" y="227" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">Istio</text>
-  <text x="600" y="242" text-anchor="middle" font-size="9"  fill="#475569">v1.30.1 · service mesh</text>
+  <text x="600" y="242" text-anchor="middle" font-size="9"  fill="#475569">v1.30.2 · service mesh</text>
 
   <rect x="696" y="209" width="160" height="46" rx="8" fill="white" stroke="#0891B2" stroke-width="1.5"/>
   <text x="776" y="227" text-anchor="middle" font-size="11" font-weight="700" fill="#0F172A">Contour</text>
@@ -240,5 +240,5 @@
   <text x="860"  y="728" font-size="10" fill="#475569">Feature flag (disabled by default)</text>
 
   <!-- footer note -->
-  <text x="600" y="754" text-anchor="middle" font-size="9" font-style="italic" fill="#94A3B8">Versions reflect versions.env and HelmRelease chart constraints as of 2026-06-12. cert-manager and openebs are deployed but inactive (commented out in the kind overlay by default).</text>
+  <text x="600" y="754" text-anchor="middle" font-size="9" font-style="italic" fill="#94A3B8">Versions reflect versions.env and HelmRelease chart constraints as of 2026-06-26. cert-manager and openebs are deployed but inactive (commented out in the kind overlay by default).</text>
 </svg>


### PR DESCRIPTION
## Summary

- Corrects all stale version numbers across README, docs, and SVGs to match the live cluster (cert-manager v1.20.3, Istio 1.30.2, kube-prometheus-stack 87.2.1, OTel 0.159.0/0.154.0, Trivy 0.33.2/0.31.2, OpenEBS 4.5.1, BOINC 950m CPU)
- Fixes factual errors: "via Gateway API" → "via Contour HTTPProxy" (§14/15 in troubleshooting guide), bootstrap step count 9→10, SOPS step reference 9/10→8/10
- Adds three new content sections: Grafana `secret_key` bootstrap rationale (README + key_concepts + sops-age-secrets + troubleshooting), resource limits rationale (README Key Design Decisions), and a new `docs/day2-operations.md` covering daily health checks, Renovate PR workflow, Kubescape score review, secret rotation, and post-sleep recovery
- Updates architecture.svg (kube-prometheus-stack 86.x→87.x) and technology-map.svg (Istio v1.30.1→v1.30.2, date stamp)
- Style: Strunk & White — active voice, direct sentences, no padding

## Test plan

- [ ] All version numbers match `kubectl get helmreleases -A` output
- [ ] `docs/day2-operations.md` opens in browser with correct markdown rendering
- [ ] SVG diagrams render with updated version strings
- [ ] `make validate` CI passes (kustomize build + Kyverno tests — no manifest changes in this PR)