### PR TITLE
fix: loosen chart constraints to allow stdlib CVE auto-remediation

### DIFF
--- a/apps/base/opentelemetry/helmrelease.yaml
+++ b/apps/base/opentelemetry/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
   chart:
     spec:
       chart: opentelemetry-collector
-      version: "0.159.x"
+      version: "0.x"
       sourceRef:
         kind: HelmRepository
         name: open-telemetry
@@ -49,11 +49,6 @@ spec:
       interval: 24h
   values:
     mode: deployment
-
-    image:
-      repository: otel/opentelemetry-collector-contrib
-      tag: "0.154.0"
-      digest: "sha256:93aad750175cbf1a973ae1c5886c3371f4d800f61be25cdd26870b8441ffe9fa"
 
     podLabels:
       sidecar.istio.io/inject: "false"

--- a/infrastructure/controllers/kubescape.yaml
+++ b/infrastructure/controllers/kubescape.yaml
@@ -18,7 +18,7 @@ spec:
   chart:
     spec:
       chart: kubescape-operator
-      version: "1.40.x"
+      version: "1.x"
       sourceRef:
         kind: HelmRepository
         name: kubescape
@@ -59,7 +59,7 @@ spec:
       # 400 "missing account id" error on every scan cycle because no account
       # or accessKey is configured. Enable offline mode to suppress this.
       kubescapeOffline: enable
-    # Known chart issue (kubescape-operator 1.40.x): the chart mounts an emptyDir
+    # Known chart issue (kubescape-operator ≤1.40.x): the chart mounts an emptyDir
     # volume with subPath: config.json at /home/nonroot/.kubescape/config.json.
     # Kubernetes creates the subPath entry as a directory before any container
     # starts, so the kubescape CLI binary finds a directory at that path instead
@@ -70,8 +70,8 @@ spec:
     # flow through the operator → storage → prometheus-exporter path, which does
     # not touch this file. Confirmed: 15 kubescape_controls_* and
     # kubescape_vulnerabilities_* metrics series are present in Prometheus after
-    # each scan cycle. Resolution: upgrade to a chart version that corrects the
-    # volume configuration. Renovate will open a PR when one is available.
+    # each scan cycle. The constraint above was widened to 1.x so Flux picks up
+    # the fix automatically when a corrected minor release is available.
     configurations:
       prometheusAnnotations: disable
 ---

--- a/infrastructure/controllers/tetragon.yaml
+++ b/infrastructure/controllers/tetragon.yaml
@@ -36,7 +36,7 @@ spec:
   chart:
     spec:
       chart: tetragon
-      version: "1.7.x"
+      version: "1.x"
       sourceRef:
         kind: HelmRepository
         name: cilium


### PR DESCRIPTION
## Summary

This PR loosens three tight minor-version chart constraints so Flux can automatically upgrade the affected components once upstream maintainers release chart versions that build their images with Go stdlib ≥1.25.10 or ≥1.26.3 (the fix for CVE-2026-39836, score 7.5).

**No newer chart versions exist in the upstream indexes today.** All three components are already at the latest available version within their current constraints. This change does not alter what is deployed right now; it removes the minor-version lock that would otherwise prevent Flux from picking up the fix automatically when chart maintainers release it.

| Component | Old constraint | New constraint | Effect |
|---|---|---|---|
| Tetragon | `1.7.x` | `1.x` | Allows 1.8.x, 1.9.x, etc. when released |
| kubescape-operator | `1.40.x` | `1.x` | Allows 1.41.x, etc.; also resolves the known `config.json is a directory` issue in 1.40.x once a corrected minor ships |
| opentelemetry-collector | `0.159.x` | `0.x` | Allows 0.160.x, 0.161.x, etc. OTel releases every ~2 weeks; a patch minor is likely imminent |

The OTel change also removes the explicit `image.tag: "0.154.0"` and `image.digest` overrides. Those values matched the chart default for `0.159.x` and would have blocked automatic image updates even if the chart version changed — the chart is now free to use its own default image for whatever version Flux resolves.

**Components with broad major-version constraints (Kyverno `3.x`, Falco `9.x`, Grafana `10.x`, Loki `7.x`, Promtail `6.x`, Tempo `1.x`, kube-prometheus-stack `87.x`, Metrics Server `3.x`) are already on the latest published chart version. Those constraints are correct and require no change.**

## Verification after merge

```bash
# Watch Flux pick up the new chart versions as they are published
flux get helmrelease -A

# Confirm the constraints are in effect
kubectl get helmchart flux-system-tetragon -n flux-system -o jsonpath='{.spec.version}'
kubectl get helmchart flux-system-kubescape -n flux-system -o jsonpath='{.spec.version}'
kubectl get helmchart flux-system-opentelemetry-collector -n flux-system -o jsonpath='{.spec.version}'
```