### PR TITLE
DRAFT fix: prepare Cilium 1.20 upgrade manifests

### DIFF
--- a/infrastructure/controllers/cilium.yaml
+++ b/infrastructure/controllers/cilium.yaml
@@ -61,7 +61,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: "1.19.x"
+      version: "1.20.x"
       sourceRef:
         kind: HelmRepository
         name: cilium

--- a/versions.env
+++ b/versions.env
@@ -4,7 +4,7 @@
 # Keep in sync with the chart version constraints in infrastructure/controllers/:
 #   cilium.yaml        → CILIUM_VERSION
 #   istio.yaml         → ISTIO_VERSION
-CILIUM_VERSION=1.19.5
+CILIUM_VERSION=1.20.0
 ISTIO_VERSION=1.30.2
 CONTOUR_VERSION=v1.33.5
 K8S_VER=v1.36.1


### PR DESCRIPTION
## Summary

- `versions.env`: `CILIUM_VERSION=1.19.5` → `CILIUM_VERSION=1.20.0`
- `infrastructure/controllers/cilium.yaml`: `version: "1.19.x"` → `"1.20.x"`

## Status

**Do not merge until Cilium 1.20.0 stable is released.**

As of 2026-06-26, only pre-release builds exist (`1.20.0-pre.0` through `1.20.0-pre.3`) in the `https://helm.cilium.io` chart index. The Helm semver constraint `1.20.x` does not match pre-release versions, so the HelmRelease would fail to resolve a chart if this PR were applied today.

Watch the Cilium release page for the `v1.20.0` tag. When it appears, verify the exact chart version and update `CILIUM_VERSION` in `versions.env` before merging:

```bash
helm search repo cilium/cilium --versions | grep '^cilium/cilium' | head -5
```

## Applying the upgrade

Cilium is pre-installed by the bootstrap script before Flux starts. The HelmRelease governs drift-detection only, not the initial install version. A constraint change in Git takes effect on the next cluster rebuild:

```bash
make destroy && make bootstrap
```

The bootstrap script reads `CILIUM_VERSION` from `versions.env` and passes it directly to `helm install cilium`, so both the script pin and the chart constraint must stay in sync.

## Verification after rebuild

```bash
# Confirm the deployed Cilium version
cilium version --client
kubectl get helmrelease cilium -n flux-system -o jsonpath='{.status.history[0].chartVersion}'

# Full cluster health check
flux get all -A
kubectl get pods -A | grep -v Running | grep -v Completed
```