### PR TITLE
fix: restore OTel image.repository after chart constraint change

### DIFF
--- a/apps/base/opentelemetry/helmrelease.yaml
+++ b/apps/base/opentelemetry/helmrelease.yaml
@@ -50,6 +50,9 @@ spec:
   values:
     mode: deployment
 
+    image:
+      repository: otel/opentelemetry-collector-contrib
+
     podLabels:
       sidecar.istio.io/inject: "false"
 


### PR DESCRIPTION
## Summary

Fixes a Helm upgrade failure introduced by PR #141.

The `opentelemetry-collector` chart (all versions ≥0.x) requires `image.repository` to be set explicitly — the chart has no built-in default and validates its presence in `NOTES.txt`:

```
[ERROR] 'image.repository' must be set.
```

PR #141 removed the stale `image.tag: "0.154.0"` and `image.digest` pins correctly, but also removed `image.repository`, triggering the error.

## Change

Restore `image.repository: otel/opentelemetry-collector-contrib` without a `tag` or `digest` override. The chart now selects its own current default image tag, which tracks the appVersion specified in the chart itself — this is the intended behaviour after loosening the chart version constraint.

## Verification

```bash
flux reconcile helmrelease opentelemetry-collector -n flux-system --with-source
flux get helmrelease opentelemetry-collector -n flux-system
kubectl get pods -n observability | grep otel
```