### PR TITLE
fix: add mutateDigest: false to verifyImages rules for Audit mode

### DIFF
--- a/apps/base/kyverno/verify-images.yaml
+++ b/apps/base/kyverno/verify-images.yaml
@@ -28,6 +28,11 @@
 #   kubectl patch clusterpolicy verify-image-signatures \
 #     --type=merge -p '{"spec":{"validationFailureAction":"Enforce"}}'
 #
+# mutateDigest: false is required on every verifyImages block when
+# validationFailureAction is Audit. Kyverno rejects the policy at admission
+# if mutateDigest is true (the default) in Audit mode because mutating the
+# digest of an already-admitted pod is undefined behaviour.
+#
 # Verification identities confirmed via cosign on 2026-06-26 against the
 # live images deployed in this cluster.
 apiVersion: kyverno.io/v1
@@ -64,6 +69,7 @@ spec:
             - "quay.io/cilium/cilium:*"
             - "quay.io/cilium/operator-generic:*"
             - "quay.io/cilium/hubble-relay:*"
+          mutateDigest: false
           attestors:
             - count: 1
               entries:
@@ -85,6 +91,7 @@ spec:
       verifyImages:
         - imageReferences:
             - "quay.io/cilium/cilium-envoy:*"
+          mutateDigest: false
           attestors:
             - count: 1
               entries:
@@ -107,6 +114,7 @@ spec:
         - imageReferences:
             - "quay.io/cilium/tetragon:*"
             - "quay.io/cilium/tetragon-operator:*"
+          mutateDigest: false
           attestors:
             - count: 1
               entries:


### PR DESCRIPTION
## Summary

- `verify-image-signatures` ClusterPolicy was rejected by Kyverno during Flux dry-run with:
  `spec.rules[0].verifyImages[0].mutateDigest: Invalid value: true: mutateDigest must be set to false for 'Audit' failure action`
- `mutateDigest` defaults to `true`, which causes Kyverno to attempt rewriting image tags to digests at admission time. This is incompatible with `validationFailureAction: Audit` because the mutation would have to block admission to be meaningful.
- Added `mutateDigest: false` to each of the three `verifyImages` blocks (`verify-cilium-core`, `verify-cilium-envoy`, `verify-tetragon`).

## Test plan

- [ ] Flux reconciles `kustomization/apps` successfully (no dry-run denial from Kyverno webhook)
- [ ] `kubectl get clusterpolicies verify-image-signatures` shows `READY: True`
- [ ] `kubectl get policyreport -A` reflects Audit-mode results for `quay.io/cilium/*` pods