### PR TITLE
fix: address cluster health issues — Tetragon OOM and Kubescape 0.00 scores

### DIFF
--- a/infrastructure/controllers/kubescape.yaml
+++ b/infrastructure/controllers/kubescape.yaml
@@ -63,17 +63,34 @@ spec:
     # volume with subPath: config.json at /home/nonroot/.kubescape/config.json.
     # Kubernetes creates the subPath entry as a directory before any container
     # starts, so the kubescape CLI binary finds a directory at that path instead
-    # of a writable file. This produces the following error on every scan cycle:
+    # of a writable file. This causes every scan cycle to fail with:
     #   open /home/nonroot/.kubescape/config.json: is a directory
-    # The error is benign. It affects only local account-state persistence, which
-    # has no purpose in offline mode (kubescapeOffline: enable). Scan results
-    # flow through the operator → storage → prometheus-exporter path, which does
-    # not touch this file. Confirmed: 15 kubescape_controls_* and
-    # kubescape_vulnerabilities_* metrics series are present in Prometheus after
-    # each scan cycle. The constraint above was widened to 1.x so Flux picks up
-    # the fix automatically when a corrected minor release is available.
+    # and produces 0.00 compliance scores across all frameworks.
+    #
+    # Workaround (postRenderers below): remove the kubescape-volume emptyDir mount
+    # entirely. With the mount gone, the image's own /home/nonroot/.kubescape/
+    # directory is used, and the kubescape binary can create config.json as a
+    # real file. The constraint above is widened to 1.x so Flux picks up the
+    # upstream chart fix automatically when a corrected release is available, at
+    # which point the postRenderers block can be removed.
     configurations:
       prometheusAnnotations: disable
+  # Remove the broken emptyDir subPath mount for config.json. See comment above.
+  # Indices confirmed against kubescape-operator 1.40.2 Deployment spec:
+  #   containers[0].volumeMounts[1] → /home/nonroot/.kubescape/config.json (subPath: config.json)
+  #   volumes[3]                    → kubescape-volume (emptyDir)
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: kubescape
+              namespace: kubescape
+            patch: |
+              - op: remove
+                path: /spec/template/spec/containers/0/volumeMounts/1
+              - op: remove
+                path: /spec/template/spec/volumes/3
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/infrastructure/controllers/tetragon.yaml
+++ b/infrastructure/controllers/tetragon.yaml
@@ -72,7 +72,7 @@ spec:
           memory: 256Mi
         limits:
           cpu: 100m
-          memory: 256Mi
+          memory: 512Mi
     # export.resources controls the export-stdout sidecar container (chart key is
     # top-level, separate from tetragon.resources which covers the main agent).
     # Without this the sidecar has no limits and fails the require-resource-limits


### PR DESCRIPTION
## Summary

Addresses two of the three issues found during the 2026-06-27 cluster log audit. Issue 1 (Flux `kustomization/apps` blocked by `mutateDigest` webhook denial) was already resolved when PR #146 merged while the audit was running.

### Issue 2 — Tetragon OOMKilled on all three nodes

All three Tetragon DaemonSet pods accumulated 2–3 OOMKilled restarts each (most recent: 90 min before audit). Live memory usage measured at 148–195 Mi against a hard 256 Mi limit, leaving only 61 Mi headroom at idle. Tetragon spikes above the limit during eBPF program load on startup and on TracingPolicy reloads.

**Fix:** Raise `tetragon.resources.limits.memory` from `256Mi` to `512Mi`. The request stays at `256Mi`, making the pod QoS class Burstable — the correct class for an agent with spiky startup behaviour and well-behaved steady state.

### Issue 3 — Kubescape compliance scores all 0.00

Every framework scan (NSA, MITRE, CIS 1.10, CIS 1.12, SOC2, etc.) was reporting a compliance score of 0.00, rendering the kubescape metrics in Prometheus meaningless. Root cause: the `kubescape-operator` chart (≤1.40.x) mounts an emptyDir volume with `subPath: config.json` at `/home/nonroot/.kubescape/config.json`. Kubernetes pre-creates the subPath entry as a directory before any container starts, so the kubescape binary opens a directory and aborts every scan with:

```
open /home/nonroot/.kubescape/config.json: is a directory
scanning failed
```

**Fix:** Add a `postRenderers` JSON6902 patch to the HelmRelease that removes both the `kubescape-volume` emptyDir volume and its corresponding volumeMount. With the mount absent, kubescape uses the image's own `/home/nonroot/.kubescape/` directory and can create `config.json` as a regular file, restoring successful scan completion. The `version: "1.x"` constraint remains in place so Flux picks up the upstream chart fix automatically; at that point the `postRenderers` block can be removed.

## Test plan

- [ ] `kubectl get pods -n tetragon` — no new OOMKilled restarts after a full eBPF reload cycle
- [ ] `kubectl top pods -n tetragon` — steady-state memory stays well below 512 Mi
- [ ] `kubectl logs -n kubescape deploy/kubescape` — no `is a directory` error; scan cycles complete successfully
- [ ] Kubescape Prometheus metrics show non-zero compliance scores: `kubectl exec -n kubescape deploy/prometheus-exporter -- wget -qO- http://localhost:8080/metrics | grep kubescape_controls`